### PR TITLE
Default the Sample metadata to the settings of the user's last created Sample

### DIFF
--- a/app/src/main/java/net/aiscope/gdd_app/dagger/AppComponent.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/dagger/AppComponent.kt
@@ -4,7 +4,6 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjectionModule
 import net.aiscope.gdd_app.application.GddApplication
-import net.aiscope.gdd_app.ui.metadata.MetadataMapper
 import javax.inject.Singleton
 
 @Singleton

--- a/app/src/main/java/net/aiscope/gdd_app/dagger/AppComponent.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/dagger/AppComponent.kt
@@ -4,6 +4,7 @@ import dagger.BindsInstance
 import dagger.Component
 import dagger.android.AndroidInjectionModule
 import net.aiscope.gdd_app.application.GddApplication
+import net.aiscope.gdd_app.ui.metadata.MetadataMapper
 import javax.inject.Singleton
 
 @Singleton

--- a/app/src/main/java/net/aiscope/gdd_app/dagger/MetadataModule.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/dagger/MetadataModule.kt
@@ -4,10 +4,8 @@ import android.app.Activity
 import dagger.Binds
 import dagger.Module
 import dagger.Provides
-import net.aiscope.gdd_app.network.RemoteStorage
-import net.aiscope.gdd_app.repository.SampleRepository
 import net.aiscope.gdd_app.ui.metadata.MetadataActivity
-import net.aiscope.gdd_app.ui.metadata.MetadataPresenter
+import net.aiscope.gdd_app.ui.metadata.MetadataMapper
 import net.aiscope.gdd_app.ui.metadata.MetadataView
 
 @Module
@@ -26,12 +24,6 @@ abstract class MetadataModule {
         @Provides
         @PerActivity
         @JvmStatic
-        internal fun providePresenter(
-            view: MetadataView,
-            repository: SampleRepository,
-            remoteStorage: RemoteStorage,
-            context: Activity
-        ): MetadataPresenter=
-            MetadataPresenter(view, repository, remoteStorage, context)
+        internal fun provideMetadataMapper(): MetadataMapper = MetadataMapper
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/model/Sample.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/model/Sample.kt
@@ -2,6 +2,7 @@ package net.aiscope.gdd_app.model
 
 import net.aiscope.gdd_app.extensions.plus
 import java.io.File
+import java.util.Calendar
 
 enum class Status(val id: Short) {
     Incomplete(0), ReadyToUpload(1), Uploaded(2)
@@ -43,7 +44,8 @@ data class Sample(
     val images: LinkedHashSet<File> = linkedSetOf(),
     val masks: LinkedHashSet<File> = linkedSetOf(),
     val metadata: SampleMetadata = SampleMetadata(),
-    val status: Status = Status.Incomplete
+    val status: Status = Status.Incomplete,
+    val createdOn: Calendar? = null
 ) {
     fun addImage(path: File) = copy(images = images + path)
 

--- a/app/src/main/java/net/aiscope/gdd_app/repository/SampleDto.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/repository/SampleDto.kt
@@ -9,6 +9,7 @@ import net.aiscope.gdd_app.model.SampleMetadata
 import net.aiscope.gdd_app.model.SmearType
 import net.aiscope.gdd_app.model.Status
 import java.io.File
+import java.util.Calendar
 
 data class SampleMetadataDto(
     @SerializedName("bloodType") val bloodType: Int,
@@ -24,7 +25,8 @@ data class SampleDto(
     val imagePaths: List<String>,
     val maskPaths: List<String>,
     val metadata: SampleMetadataDto,
-    val status: Short
+    val status: Short,
+    val createdOn: Calendar? = null
 ) {
     fun toDomain(): Sample = Sample(
         id = id,
@@ -38,7 +40,8 @@ data class SampleDto(
             MalariaSpecies.values().first { it.id == metadata.species },
             MalariaStage.values().first { it.id == metadata.stage }
         ),
-        status = Status.values().first { it.id == status }
+        status = Status.values().first { it.id == status },
+        createdOn = createdOn
     )
 }
 
@@ -50,5 +53,6 @@ fun Sample.toDto() = SampleDto(
     imagePaths = images.map { it.absolutePath },
     maskPaths = masks.map { it.absolutePath },
     metadata = SampleMetadataDto(metadata.smearType.id, metadata.species.id, metadata.stage.id),
-    status = status.id
+    status = status.id,
+    createdOn = createdOn
 )

--- a/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepository.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepository.kt
@@ -9,4 +9,5 @@ interface SampleRepository {
     suspend fun current(): Sample
 
     fun all(): List<Sample>
+    suspend fun last(): Sample?
 }

--- a/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
@@ -58,6 +58,6 @@ class SampleRepositorySharedPreference @Inject constructor(
                         && s.microscopist == facility.microscopist
                         && s.createdOn != null
                         && s.status != Status.Incomplete}
-            .sortedWith(compareBy {it.createdOn}).lastOrNull()
+            .sortedBy { it.createdOn }.lastOrNull()
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
@@ -3,6 +3,8 @@ package net.aiscope.gdd_app.repository
 import com.github.salomonbrys.kotson.fromJson
 import com.google.gson.Gson
 import net.aiscope.gdd_app.model.Sample
+import net.aiscope.gdd_app.model.Status
+import java.util.Calendar
 import javax.inject.Inject
 
 class SampleRepositorySharedPreference @Inject constructor(
@@ -21,7 +23,7 @@ class SampleRepositorySharedPreference @Inject constructor(
     override suspend fun create(): Sample {
         val uuid = uuid.generateUUID()
         val facility = healthFacilityRepository.load()
-        val sample = Sample(uuid, facility.id, facility.microscopist)
+        val sample = Sample(uuid, facility.id, facility.microscopist, createdOn = Calendar.getInstance())
 
         currentSample = sample
         return sample
@@ -46,5 +48,16 @@ class SampleRepositorySharedPreference @Inject constructor(
         return jsons.map {
             gson.fromJson<SampleDto>(it).toDomain()
         }.toList()
+    }
+
+    override suspend fun last(): Sample? {
+        val allStores = all()
+        val facility = healthFacilityRepository.load()
+        return allStores
+            .filter{s -> s.healthFacility == facility.id
+                        && s.microscopist == facility.microscopist
+                        && s.createdOn != null
+                        && s.status != Status.Incomplete}
+            .sortedWith(compareBy {it.createdOn}).lastOrNull()
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
@@ -52,11 +52,8 @@ class SampleRepositorySharedPreference @Inject constructor(
 
     override suspend fun last(): Sample? {
         val allStores = all()
-        val facility = healthFacilityRepository.load()
         return allStores
-            .filter{s -> s.healthFacility == facility.id
-                        && s.microscopist == facility.microscopist
-                        && s.createdOn != null
+            .filter{s -> s.createdOn != null
                         && s.status != Status.Incomplete}
             .sortedBy { it.createdOn }.lastOrNull()
     }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -61,7 +61,7 @@ class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
         var index = -1
         for (i in 0 until spinner.adapter.count){
             if (spinner.adapter.getItem(i) == value) {
-                index = 1
+                index = i
                 break;
             }
         }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -58,15 +58,9 @@ class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
     }
 
     private fun selectSpinnerValue(spinner: AbsSpinner, value: String) {
-        var index = -1
-        for (i in 0 until spinner.adapter.count){
-            if (spinner.adapter.getItem(i) == value) {
-                index = i
-                break;
-            }
-        }
-        if (index > -1)
-            spinner.setSelection(index)
+        (0 until spinner.adapter.count)
+            .firstOrNull { spinner.adapter.getItem(it) == value }
+            ?.let { spinner.setSelection(it) }
     }
 
     override fun onDestroy() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -50,9 +50,10 @@ class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
         metadata_save_sample.setOnClickListener {
             coroutineScope.launch {
                 presenter.save(
-                    MetadataMapper.getSmearType(metadata_section_smear_type_radio_group.checkedRadioButtonId),
-                    MetadataMapper.getSpecies(baseContext, metadata_species_spinner.selectedItem),
-                    MetadataMapper.getStage(baseContext, metadata_stage_spinner.selectedItem))
+                    metadata_section_smear_type_radio_group.checkedRadioButtonId,
+                    metadata_species_spinner.selectedItem.toString(),
+                    metadata_stage_spinner.selectedItem.toString()
+                )
             }
         }
     }
@@ -70,9 +71,9 @@ class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
 
     override fun fillForm(model: ViewStateModel) {
         imagesAdapter.setImages(model.images)
-        model.smearType?.let { metadata_section_smear_type_radio_group.check(it) }
-        model.species?.let { selectSpinnerValue(metadata_species_spinner, it) }
-        model.stage?.let { selectSpinnerValue(metadata_stage_spinner, it) }
+        model.smearTypeId?.let { metadata_section_smear_type_radio_group.check(it) }
+        model.speciesValue?.let { selectSpinnerValue(metadata_species_spinner, it) }
+        model.stageValue?.let { selectSpinnerValue(metadata_stage_spinner, it) }
     }
 
     override fun showInvalidFormError() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -70,15 +70,9 @@ class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
 
     override fun fillForm(model: ViewStateModel) {
         imagesAdapter.setImages(model.images)
-        if (model.sampleMetadata != null) {
-            metadata_section_smear_type_radio_group.check(MetadataMapper.getSmearTypeId(model.sampleMetadata.smearType))
-            selectSpinnerValue(
-                metadata_species_spinner,
-                MetadataMapper.getSpeciesValue(baseContext, model.sampleMetadata.species))
-            selectSpinnerValue(
-                metadata_stage_spinner,
-                MetadataMapper.getStageValue(baseContext, model.sampleMetadata.stage))
-        }
+        model.smearType?.let { metadata_section_smear_type_radio_group.check(it) }
+        model.species?.let { selectSpinnerValue(metadata_species_spinner, it) }
+        model.stage?.let { selectSpinnerValue(metadata_stage_spinner, it) }
     }
 
     override fun showInvalidFormError() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataMapper.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataMapper.kt
@@ -1,0 +1,80 @@
+package net.aiscope.gdd_app.ui.metadata
+
+import android.content.Context
+import android.content.res.Resources
+import net.aiscope.gdd_app.R
+import net.aiscope.gdd_app.model.MalariaSpecies
+import net.aiscope.gdd_app.model.MalariaStage
+import net.aiscope.gdd_app.model.SmearType
+
+class MetadataMapper {
+    private constructor () { /* make constructor private for utility class */ }
+    companion object MetadataMapperCompanion {
+        @JvmStatic
+        fun getSmearType(smearTypeId: Int): SmearType {
+            return when (smearTypeId) {
+                R.id.metadata_blood_smear_thick -> SmearType.THICK
+                R.id.metadata_blood_smear_thin -> SmearType.THIN
+                else -> throw IllegalStateException(
+                    "$smearTypeId smearTypeId is unknown"
+                )
+            }
+        }
+
+        @JvmStatic
+        fun getSmearTypeId(smearType: SmearType): Int {
+            return when (smearType) {
+                SmearType.THICK -> R.id.metadata_blood_smear_thick
+                SmearType.THIN -> R.id.metadata_blood_smear_thin
+            }
+        }
+
+        @JvmStatic
+        fun getSpecies(context: Context, speciesValue: Any): MalariaSpecies {
+            return when (speciesValue) {
+                context.getString(R.string.malaria_species_p_falciparum) -> MalariaSpecies.P_FALCIPARUM
+                context.getString(R.string.malaria_species_p_vivax) -> MalariaSpecies.P_VIVAX
+                context.getString(R.string.malaria_species_p_ovale) -> MalariaSpecies.P_OVALE
+                context.getString(R.string.malaria_species_p_malariae) -> MalariaSpecies.P_MALARIAE
+                context.getString(R.string.malaria_species_p_knowlesi) -> MalariaSpecies.P_KNOWLESI
+                else -> throw IllegalStateException(
+                    "$speciesValue species is unknown"
+                )
+            }
+        }
+
+        @JvmStatic
+        fun getSpeciesValue(context: Context, species: MalariaSpecies): String {
+            return when(species) {
+                MalariaSpecies.P_FALCIPARUM -> context.getString(R.string.malaria_species_p_falciparum)
+                MalariaSpecies.P_VIVAX -> context.getString(R.string.malaria_species_p_vivax)
+                MalariaSpecies.P_OVALE -> context.getString(R.string.malaria_species_p_ovale)
+                MalariaSpecies.P_MALARIAE -> context.getString(R.string.malaria_species_p_malariae)
+                MalariaSpecies.P_KNOWLESI -> context.getString(R.string.malaria_species_p_knowlesi)
+            }
+        }
+
+        @JvmStatic
+        fun getStage(context: Context, stageValue: Any): MalariaStage {
+            return when (stageValue) {
+                context.getString(R.string.malaria_stage_ring) -> MalariaStage.RING
+                context.getString(R.string.malaria_stage_trophozoite) -> MalariaStage.TROPHOZOITE
+                context.getString(R.string.malaria_stage_schizont) -> MalariaStage.SCHIZONT
+                context.getString(R.string.malaria_stage_gametocyte) -> MalariaStage.GAMETOCYTE
+                else -> throw IllegalStateException(
+                    "$stageValue stage is unknown"
+                )
+            }
+        }
+
+        @JvmStatic
+        fun getStageValue(context: Context, stage: MalariaStage): String {
+            return when(stage) {
+                MalariaStage.RING -> context.getString(R.string.malaria_stage_ring)
+                MalariaStage.TROPHOZOITE -> context.getString(R.string.malaria_stage_trophozoite)
+                MalariaStage.SCHIZONT -> context.getString(R.string.malaria_stage_schizont)
+                MalariaStage.GAMETOCYTE -> context.getString(R.string.malaria_stage_gametocyte)
+            }
+        }
+    }
+}

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataMapper.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataMapper.kt
@@ -4,6 +4,7 @@ import android.content.Context
 import net.aiscope.gdd_app.R
 import net.aiscope.gdd_app.model.MalariaSpecies
 import net.aiscope.gdd_app.model.MalariaStage
+import net.aiscope.gdd_app.model.SampleMetadata
 import net.aiscope.gdd_app.model.SmearType
 
 object MetadataMapper {
@@ -17,14 +18,15 @@ object MetadataMapper {
         }
     }
 
-    fun getSmearTypeId(smearType: SmearType): Int {
-        return when (smearType) {
+    fun getSmearTypeId(metadata: SampleMetadata?): Int? {
+        return when (metadata?.smearType) {
             SmearType.THICK -> R.id.metadata_blood_smear_thick
             SmearType.THIN -> R.id.metadata_blood_smear_thin
+            else -> return null;
         }
     }
 
-    fun getSpecies(context: Context, speciesValue: Any): MalariaSpecies {
+    fun getSpecies(context: Context, speciesValue: String): MalariaSpecies {
         return when (speciesValue) {
             context.getString(R.string.malaria_species_p_falciparum) -> MalariaSpecies.P_FALCIPARUM
             context.getString(R.string.malaria_species_p_vivax) -> MalariaSpecies.P_VIVAX
@@ -37,17 +39,18 @@ object MetadataMapper {
         }
     }
 
-    fun getSpeciesValue(context: Context, species: MalariaSpecies): String {
-        return when (species) {
+    fun getSpeciesValue(context: Context, metadata: SampleMetadata?): String? {
+        return when (metadata?.species) {
             MalariaSpecies.P_FALCIPARUM -> context.getString(R.string.malaria_species_p_falciparum)
             MalariaSpecies.P_VIVAX -> context.getString(R.string.malaria_species_p_vivax)
             MalariaSpecies.P_OVALE -> context.getString(R.string.malaria_species_p_ovale)
             MalariaSpecies.P_MALARIAE -> context.getString(R.string.malaria_species_p_malariae)
             MalariaSpecies.P_KNOWLESI -> context.getString(R.string.malaria_species_p_knowlesi)
+            else -> return null;
         }
     }
 
-    fun getStage(context: Context, stageValue: Any): MalariaStage {
+    fun getStage(context: Context, stageValue: String): MalariaStage {
         return when (stageValue) {
             context.getString(R.string.malaria_stage_ring) -> MalariaStage.RING
             context.getString(R.string.malaria_stage_trophozoite) -> MalariaStage.TROPHOZOITE
@@ -59,12 +62,13 @@ object MetadataMapper {
         }
     }
 
-    fun getStageValue(context: Context, stage: MalariaStage): String {
-        return when (stage) {
+    fun getStageValue(context: Context, metadata: SampleMetadata?): String? {
+        return when (metadata?.stage) {
             MalariaStage.RING -> context.getString(R.string.malaria_stage_ring)
             MalariaStage.TROPHOZOITE -> context.getString(R.string.malaria_stage_trophozoite)
             MalariaStage.SCHIZONT -> context.getString(R.string.malaria_stage_schizont)
             MalariaStage.GAMETOCYTE -> context.getString(R.string.malaria_stage_gametocyte)
+            else -> return null;
         }
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataMapper.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataMapper.kt
@@ -1,80 +1,70 @@
 package net.aiscope.gdd_app.ui.metadata
 
 import android.content.Context
-import android.content.res.Resources
 import net.aiscope.gdd_app.R
 import net.aiscope.gdd_app.model.MalariaSpecies
 import net.aiscope.gdd_app.model.MalariaStage
 import net.aiscope.gdd_app.model.SmearType
 
-class MetadataMapper {
-    private constructor () { /* make constructor private for utility class */ }
-    companion object MetadataMapperCompanion {
-        @JvmStatic
-        fun getSmearType(smearTypeId: Int): SmearType {
-            return when (smearTypeId) {
-                R.id.metadata_blood_smear_thick -> SmearType.THICK
-                R.id.metadata_blood_smear_thin -> SmearType.THIN
-                else -> throw IllegalStateException(
-                    "$smearTypeId smearTypeId is unknown"
-                )
-            }
+object MetadataMapper {
+    fun getSmearType(smearTypeId: Int): SmearType {
+        return when (smearTypeId) {
+            R.id.metadata_blood_smear_thick -> SmearType.THICK
+            R.id.metadata_blood_smear_thin -> SmearType.THIN
+            else -> throw IllegalStateException(
+                "$smearTypeId smearTypeId is unknown"
+            )
         }
+    }
 
-        @JvmStatic
-        fun getSmearTypeId(smearType: SmearType): Int {
-            return when (smearType) {
-                SmearType.THICK -> R.id.metadata_blood_smear_thick
-                SmearType.THIN -> R.id.metadata_blood_smear_thin
-            }
+    fun getSmearTypeId(smearType: SmearType): Int {
+        return when (smearType) {
+            SmearType.THICK -> R.id.metadata_blood_smear_thick
+            SmearType.THIN -> R.id.metadata_blood_smear_thin
         }
+    }
 
-        @JvmStatic
-        fun getSpecies(context: Context, speciesValue: Any): MalariaSpecies {
-            return when (speciesValue) {
-                context.getString(R.string.malaria_species_p_falciparum) -> MalariaSpecies.P_FALCIPARUM
-                context.getString(R.string.malaria_species_p_vivax) -> MalariaSpecies.P_VIVAX
-                context.getString(R.string.malaria_species_p_ovale) -> MalariaSpecies.P_OVALE
-                context.getString(R.string.malaria_species_p_malariae) -> MalariaSpecies.P_MALARIAE
-                context.getString(R.string.malaria_species_p_knowlesi) -> MalariaSpecies.P_KNOWLESI
-                else -> throw IllegalStateException(
-                    "$speciesValue species is unknown"
-                )
-            }
+    fun getSpecies(context: Context, speciesValue: Any): MalariaSpecies {
+        return when (speciesValue) {
+            context.getString(R.string.malaria_species_p_falciparum) -> MalariaSpecies.P_FALCIPARUM
+            context.getString(R.string.malaria_species_p_vivax) -> MalariaSpecies.P_VIVAX
+            context.getString(R.string.malaria_species_p_ovale) -> MalariaSpecies.P_OVALE
+            context.getString(R.string.malaria_species_p_malariae) -> MalariaSpecies.P_MALARIAE
+            context.getString(R.string.malaria_species_p_knowlesi) -> MalariaSpecies.P_KNOWLESI
+            else -> throw IllegalStateException(
+                "$speciesValue species is unknown"
+            )
         }
+    }
 
-        @JvmStatic
-        fun getSpeciesValue(context: Context, species: MalariaSpecies): String {
-            return when(species) {
-                MalariaSpecies.P_FALCIPARUM -> context.getString(R.string.malaria_species_p_falciparum)
-                MalariaSpecies.P_VIVAX -> context.getString(R.string.malaria_species_p_vivax)
-                MalariaSpecies.P_OVALE -> context.getString(R.string.malaria_species_p_ovale)
-                MalariaSpecies.P_MALARIAE -> context.getString(R.string.malaria_species_p_malariae)
-                MalariaSpecies.P_KNOWLESI -> context.getString(R.string.malaria_species_p_knowlesi)
-            }
+    fun getSpeciesValue(context: Context, species: MalariaSpecies): String {
+        return when (species) {
+            MalariaSpecies.P_FALCIPARUM -> context.getString(R.string.malaria_species_p_falciparum)
+            MalariaSpecies.P_VIVAX -> context.getString(R.string.malaria_species_p_vivax)
+            MalariaSpecies.P_OVALE -> context.getString(R.string.malaria_species_p_ovale)
+            MalariaSpecies.P_MALARIAE -> context.getString(R.string.malaria_species_p_malariae)
+            MalariaSpecies.P_KNOWLESI -> context.getString(R.string.malaria_species_p_knowlesi)
         }
+    }
 
-        @JvmStatic
-        fun getStage(context: Context, stageValue: Any): MalariaStage {
-            return when (stageValue) {
-                context.getString(R.string.malaria_stage_ring) -> MalariaStage.RING
-                context.getString(R.string.malaria_stage_trophozoite) -> MalariaStage.TROPHOZOITE
-                context.getString(R.string.malaria_stage_schizont) -> MalariaStage.SCHIZONT
-                context.getString(R.string.malaria_stage_gametocyte) -> MalariaStage.GAMETOCYTE
-                else -> throw IllegalStateException(
-                    "$stageValue stage is unknown"
-                )
-            }
+    fun getStage(context: Context, stageValue: Any): MalariaStage {
+        return when (stageValue) {
+            context.getString(R.string.malaria_stage_ring) -> MalariaStage.RING
+            context.getString(R.string.malaria_stage_trophozoite) -> MalariaStage.TROPHOZOITE
+            context.getString(R.string.malaria_stage_schizont) -> MalariaStage.SCHIZONT
+            context.getString(R.string.malaria_stage_gametocyte) -> MalariaStage.GAMETOCYTE
+            else -> throw IllegalStateException(
+                "$stageValue stage is unknown"
+            )
         }
+    }
 
-        @JvmStatic
-        fun getStageValue(context: Context, stage: MalariaStage): String {
-            return when(stage) {
-                MalariaStage.RING -> context.getString(R.string.malaria_stage_ring)
-                MalariaStage.TROPHOZOITE -> context.getString(R.string.malaria_stage_trophozoite)
-                MalariaStage.SCHIZONT -> context.getString(R.string.malaria_stage_schizont)
-                MalariaStage.GAMETOCYTE -> context.getString(R.string.malaria_stage_gametocyte)
-            }
+    fun getStageValue(context: Context, stage: MalariaStage): String {
+        return when (stage) {
+            MalariaStage.RING -> context.getString(R.string.malaria_stage_ring)
+            MalariaStage.TROPHOZOITE -> context.getString(R.string.malaria_stage_trophozoite)
+            MalariaStage.SCHIZONT -> context.getString(R.string.malaria_stage_schizont)
+            MalariaStage.GAMETOCYTE -> context.getString(R.string.malaria_stage_gametocyte)
         }
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataMapper.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataMapper.kt
@@ -4,7 +4,6 @@ import android.content.Context
 import net.aiscope.gdd_app.R
 import net.aiscope.gdd_app.model.MalariaSpecies
 import net.aiscope.gdd_app.model.MalariaStage
-import net.aiscope.gdd_app.model.SampleMetadata
 import net.aiscope.gdd_app.model.SmearType
 
 object MetadataMapper {
@@ -18,11 +17,10 @@ object MetadataMapper {
         }
     }
 
-    fun getSmearTypeId(metadata: SampleMetadata?): Int? {
-        return when (metadata?.smearType) {
+    fun getSmearTypeId(smearType: SmearType): Int {
+        return when (smearType) {
             SmearType.THICK -> R.id.metadata_blood_smear_thick
             SmearType.THIN -> R.id.metadata_blood_smear_thin
-            else -> return null;
         }
     }
 
@@ -39,14 +37,13 @@ object MetadataMapper {
         }
     }
 
-    fun getSpeciesValue(context: Context, metadata: SampleMetadata?): String? {
-        return when (metadata?.species) {
+    fun getSpeciesValue(context: Context, species: MalariaSpecies): String {
+        return when (species) {
             MalariaSpecies.P_FALCIPARUM -> context.getString(R.string.malaria_species_p_falciparum)
             MalariaSpecies.P_VIVAX -> context.getString(R.string.malaria_species_p_vivax)
             MalariaSpecies.P_OVALE -> context.getString(R.string.malaria_species_p_ovale)
             MalariaSpecies.P_MALARIAE -> context.getString(R.string.malaria_species_p_malariae)
             MalariaSpecies.P_KNOWLESI -> context.getString(R.string.malaria_species_p_knowlesi)
-            else -> return null;
         }
     }
 
@@ -62,13 +59,12 @@ object MetadataMapper {
         }
     }
 
-    fun getStageValue(context: Context, metadata: SampleMetadata?): String? {
-        return when (metadata?.stage) {
+    fun getStageValue(context: Context, stage: MalariaStage): String {
+        return when (stage) {
             MalariaStage.RING -> context.getString(R.string.malaria_stage_ring)
             MalariaStage.TROPHOZOITE -> context.getString(R.string.malaria_stage_trophozoite)
             MalariaStage.SCHIZONT -> context.getString(R.string.malaria_stage_schizont)
             MalariaStage.GAMETOCYTE -> context.getString(R.string.malaria_stage_gametocyte)
-            else -> return null;
         }
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
@@ -16,7 +16,8 @@ data class ViewStateModel(
     val disease: String,
     val images: List<File>,
     val options: List<FieldOption>,
-    val required: Boolean = true
+    val required: Boolean = true,
+    val sampleMetadata: SampleMetadata? = null
 )
 
 class MetadataPresenter @Inject constructor(
@@ -34,7 +35,12 @@ class MetadataPresenter @Inject constructor(
             return
         }
 
-        view.fillForm(ViewStateModel(sample.disease, sample.images.toList(), emptyList()))
+        view.fillForm(
+            ViewStateModel(
+                sample.disease,
+                sample.images.toList(),
+                emptyList(),
+                sampleMetadata = repository.last()?.metadata))
     }
 
     fun notValid() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
@@ -17,7 +17,9 @@ data class ViewStateModel(
     val images: List<File>,
     val options: List<FieldOption>,
     val required: Boolean = true,
-    val sampleMetadata: SampleMetadata? = null
+    val smearType: Int? = null,
+    val species: String? = null,
+    val stage: String? = null
 )
 
 class MetadataPresenter @Inject constructor(
@@ -35,12 +37,17 @@ class MetadataPresenter @Inject constructor(
             return
         }
 
+        val lastMetadata = repository.last()?.metadata
         view.fillForm(
             ViewStateModel(
                 sample.disease,
                 sample.images.toList(),
                 emptyList(),
-                sampleMetadata = repository.last()?.metadata))
+                smearType = lastMetadata?.let { MetadataMapper.getSmearTypeId(it.smearType) },
+                species = lastMetadata?.let { MetadataMapper.getSpeciesValue(context, it.species) },
+                stage = lastMetadata?.let { MetadataMapper.getStageValue(context, it.stage) }
+            )
+        )
     }
 
     fun notValid() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
@@ -22,6 +22,7 @@ data class ViewStateModel(
 class MetadataPresenter @Inject constructor(
     private val view: MetadataView,
     private val repository: SampleRepository,
+    private val metadataMapper: MetadataMapper,
     private val remoteStorage: RemoteStorage,
     private val context: Context
 ) {
@@ -40,9 +41,9 @@ class MetadataPresenter @Inject constructor(
                 sample.disease,
                 sample.images.toList(),
                 emptyList(),
-                smearTypeId = MetadataMapper.getSmearTypeId(lastMetadata),
-                speciesValue = MetadataMapper.getSpeciesValue(context, lastMetadata),
-                stageValue = MetadataMapper.getStageValue(context, lastMetadata)
+                smearTypeId = lastMetadata?.let { metadataMapper.getSmearTypeId(it.smearType) },
+                speciesValue = lastMetadata?.let { metadataMapper.getSpeciesValue(context, it.species) },
+                stageValue = lastMetadata?.let { metadataMapper.getStageValue(context, it.stage) }
             )
         )
     }
@@ -54,9 +55,9 @@ class MetadataPresenter @Inject constructor(
     suspend fun save(smearTypeId: Int, speciesValue: String, stageValue: String) {
         val sample = repository.current()
             .copy(metadata = SampleMetadata(
-                    MetadataMapper.getSmearType(smearTypeId),
-                    MetadataMapper.getSpecies(context, speciesValue),
-                    MetadataMapper.getStage(context, stageValue)
+                    metadataMapper.getSmearType(smearTypeId),
+                    metadataMapper.getSpecies(context, speciesValue),
+                    metadataMapper.getStage(context, stageValue)
                 ), status = Status.ReadyToUpload
             )
         repository.store(sample)

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataMapperTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataMapperTest.kt
@@ -1,0 +1,103 @@
+package net.aiscope.gdd_app.presentation
+
+import android.content.Context
+import com.nhaarman.mockito_kotlin.whenever
+import kotlinx.coroutines.ExperimentalCoroutinesApi
+import net.aiscope.gdd_app.CoroutineTestRule
+import net.aiscope.gdd_app.R
+import net.aiscope.gdd_app.model.MalariaSpecies
+import net.aiscope.gdd_app.model.MalariaStage
+import net.aiscope.gdd_app.model.SmearType
+import net.aiscope.gdd_app.ui.metadata.MetadataMapper
+import org.junit.Assert.assertEquals
+import org.junit.Before
+import org.junit.Rule
+import org.junit.Test
+import org.junit.runner.RunWith
+import org.mockito.Mock
+import org.mockito.junit.MockitoJUnitRunner
+
+@ExperimentalCoroutinesApi
+@RunWith(MockitoJUnitRunner::class)
+class MetadataMapperTest {
+    @get:Rule
+    var coroutinesTestRule = CoroutineTestRule()
+
+    @Mock
+    lateinit var context: Context
+
+    @Before
+    fun before() = coroutinesTestRule.runBlockingTest {
+        whenever(context.getString(R.string.malaria_species_p_falciparum))
+            .thenReturn("P. falciparum")
+        whenever(context.getString(R.string.malaria_species_p_vivax))
+            .thenReturn("P. vivax")
+        whenever(context.getString(R.string.malaria_species_p_ovale))
+            .thenReturn("P. ovale")
+        whenever(context.getString(R.string.malaria_species_p_malariae))
+            .thenReturn("P. malariae")
+        whenever(context.getString(R.string.malaria_species_p_knowlesi))
+            .thenReturn("P. knowlesi")
+
+        whenever(context.getString(R.string.malaria_stage_ring))
+            .thenReturn("Ring")
+        whenever(context.getString(R.string.malaria_stage_trophozoite))
+            .thenReturn("Trophozoite")
+        whenever(context.getString(R.string.malaria_stage_schizont))
+            .thenReturn("Schizont")
+        whenever(context.getString(R.string.malaria_stage_gametocyte))
+            .thenReturn("Gametocyte")
+    }
+
+    @Test
+    fun shouldReturnSmearType() =
+        coroutinesTestRule.runBlockingTest {
+            assertEquals(SmearType.THICK, MetadataMapper.getSmearType(R.id.metadata_blood_smear_thick))
+            assertEquals(SmearType.THIN, MetadataMapper.getSmearType(R.id.metadata_blood_smear_thin))
+        }
+
+    @Test
+    fun shouldReturnSmearTypeId() =
+        coroutinesTestRule.runBlockingTest {
+            assertEquals(R.id.metadata_blood_smear_thick, MetadataMapper.getSmearTypeId(SmearType.THICK))
+            assertEquals(R.id.metadata_blood_smear_thin, MetadataMapper.getSmearTypeId(SmearType.THIN))
+        }
+
+    @Test
+    fun shouldReturnSpecies() =
+        coroutinesTestRule.runBlockingTest {
+            assertEquals(MalariaSpecies.P_FALCIPARUM, MetadataMapper.getSpecies(context,"P. falciparum"))
+            assertEquals(MalariaSpecies.P_VIVAX, MetadataMapper.getSpecies(context,"P. vivax"))
+            assertEquals(MalariaSpecies.P_OVALE, MetadataMapper.getSpecies(context,"P. ovale"))
+            assertEquals(MalariaSpecies.P_MALARIAE, MetadataMapper.getSpecies(context,"P. malariae"))
+            assertEquals(MalariaSpecies.P_KNOWLESI, MetadataMapper.getSpecies(context,"P. knowlesi"))
+        }
+
+    @Test
+    fun shouldReturnSpeciesValue() =
+        coroutinesTestRule.runBlockingTest {
+            assertEquals("P. falciparum", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_FALCIPARUM))
+            assertEquals("P. vivax", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_VIVAX))
+            assertEquals("P. ovale", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_OVALE))
+            assertEquals("P. malariae", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_MALARIAE))
+            assertEquals("P. knowlesi", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_KNOWLESI))
+        }
+
+    @Test
+    fun shouldReturnStage() =
+        coroutinesTestRule.runBlockingTest {
+            assertEquals(MalariaStage.RING, MetadataMapper.getStage(context, "Ring"))
+            assertEquals(MalariaStage.TROPHOZOITE, MetadataMapper.getStage(context, "Trophozoite"))
+            assertEquals(MalariaStage.SCHIZONT, MetadataMapper.getStage(context, "Schizont"))
+            assertEquals(MalariaStage.GAMETOCYTE, MetadataMapper.getStage(context, "Gametocyte"))
+        }
+
+    @Test
+    fun shouldReturnStageValue() =
+        coroutinesTestRule.runBlockingTest {
+            assertEquals("Ring", MetadataMapper.getStageValue(context, MalariaStage.RING))
+            assertEquals("Trophozoite", MetadataMapper.getStageValue(context, MalariaStage.TROPHOZOITE))
+            assertEquals("Schizont", MetadataMapper.getStageValue(context, MalariaStage.SCHIZONT))
+            assertEquals("Gametocyte", MetadataMapper.getStageValue(context, MalariaStage.GAMETOCYTE))
+        }
+}

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataMapperTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataMapperTest.kt
@@ -5,7 +5,6 @@ import com.nhaarman.mockito_kotlin.whenever
 import net.aiscope.gdd_app.R
 import net.aiscope.gdd_app.model.MalariaSpecies
 import net.aiscope.gdd_app.model.MalariaStage
-import net.aiscope.gdd_app.model.SampleMetadata
 import net.aiscope.gdd_app.model.SmearType
 import net.aiscope.gdd_app.ui.metadata.MetadataMapper
 import org.junit.Assert.assertEquals
@@ -45,47 +44,47 @@ class MetadataMapperTest {
 
     @Test
     fun shouldReturnSmearType() {
-            assertEquals(SmearType.THICK, MetadataMapper.getSmearType(R.id.metadata_blood_smear_thick))
-            assertEquals(SmearType.THIN, MetadataMapper.getSmearType(R.id.metadata_blood_smear_thin))
-        }
+        assertEquals(SmearType.THICK, MetadataMapper.getSmearType(R.id.metadata_blood_smear_thick))
+        assertEquals(SmearType.THIN, MetadataMapper.getSmearType(R.id.metadata_blood_smear_thin))
+    }
 
     @Test
     fun shouldReturnSmearTypeId() {
-            assertEquals(R.id.metadata_blood_smear_thick, MetadataMapper.getSmearTypeId(SampleMetadata(smearType = SmearType.THICK)))
-            assertEquals(R.id.metadata_blood_smear_thin, MetadataMapper.getSmearTypeId(SampleMetadata(smearType = SmearType.THIN)))
-        }
+        assertEquals(R.id.metadata_blood_smear_thick, MetadataMapper.getSmearTypeId(SmearType.THICK))
+        assertEquals(R.id.metadata_blood_smear_thin, MetadataMapper.getSmearTypeId(SmearType.THIN))
+    }
 
     @Test
     fun shouldReturnSpecies() {
-            assertEquals(MalariaSpecies.P_FALCIPARUM, MetadataMapper.getSpecies(context,"P. falciparum"))
-            assertEquals(MalariaSpecies.P_VIVAX, MetadataMapper.getSpecies(context,"P. vivax"))
-            assertEquals(MalariaSpecies.P_OVALE, MetadataMapper.getSpecies(context,"P. ovale"))
-            assertEquals(MalariaSpecies.P_MALARIAE, MetadataMapper.getSpecies(context,"P. malariae"))
-            assertEquals(MalariaSpecies.P_KNOWLESI, MetadataMapper.getSpecies(context,"P. knowlesi"))
-        }
+        assertEquals(MalariaSpecies.P_FALCIPARUM, MetadataMapper.getSpecies(context, "P. falciparum"))
+        assertEquals(MalariaSpecies.P_VIVAX, MetadataMapper.getSpecies(context, "P. vivax"))
+        assertEquals(MalariaSpecies.P_OVALE, MetadataMapper.getSpecies(context, "P. ovale"))
+        assertEquals(MalariaSpecies.P_MALARIAE, MetadataMapper.getSpecies(context, "P. malariae"))
+        assertEquals(MalariaSpecies.P_KNOWLESI, MetadataMapper.getSpecies(context, "P. knowlesi"))
+    }
 
     @Test
     fun shouldReturnSpeciesValue() {
-            assertEquals("P. falciparum", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_FALCIPARUM)))
-            assertEquals("P. vivax", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_VIVAX)))
-            assertEquals("P. ovale", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_OVALE)))
-            assertEquals("P. malariae", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_MALARIAE)))
-            assertEquals("P. knowlesi", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_KNOWLESI)))
-        }
+        assertEquals("P. falciparum", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_FALCIPARUM))
+        assertEquals("P. vivax", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_VIVAX))
+        assertEquals("P. ovale", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_OVALE))
+        assertEquals("P. malariae", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_MALARIAE))
+        assertEquals("P. knowlesi", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_KNOWLESI))
+    }
 
     @Test
     fun shouldReturnStage() {
-            assertEquals(MalariaStage.RING, MetadataMapper.getStage(context, "Ring"))
-            assertEquals(MalariaStage.TROPHOZOITE, MetadataMapper.getStage(context, "Trophozoite"))
-            assertEquals(MalariaStage.SCHIZONT, MetadataMapper.getStage(context, "Schizont"))
-            assertEquals(MalariaStage.GAMETOCYTE, MetadataMapper.getStage(context, "Gametocyte"))
-        }
+        assertEquals(MalariaStage.RING, MetadataMapper.getStage(context, "Ring"))
+        assertEquals(MalariaStage.TROPHOZOITE, MetadataMapper.getStage(context, "Trophozoite"))
+        assertEquals(MalariaStage.SCHIZONT, MetadataMapper.getStage(context, "Schizont"))
+        assertEquals(MalariaStage.GAMETOCYTE, MetadataMapper.getStage(context, "Gametocyte"))
+    }
 
     @Test
     fun shouldReturnStageValue() {
-            assertEquals("Ring", MetadataMapper.getStageValue(context, SampleMetadata(stage = MalariaStage.RING)))
-            assertEquals("Trophozoite", MetadataMapper.getStageValue(context, SampleMetadata(stage = MalariaStage.TROPHOZOITE)))
-            assertEquals("Schizont", MetadataMapper.getStageValue(context, SampleMetadata(stage = MalariaStage.SCHIZONT)))
-            assertEquals("Gametocyte", MetadataMapper.getStageValue(context, SampleMetadata(stage = MalariaStage.GAMETOCYTE)))
-        }
+        assertEquals("Ring", MetadataMapper.getStageValue(context, MalariaStage.RING))
+        assertEquals("Trophozoite", MetadataMapper.getStageValue(context, MalariaStage.TROPHOZOITE))
+        assertEquals("Schizont", MetadataMapper.getStageValue(context, MalariaStage.SCHIZONT))
+        assertEquals("Gametocyte", MetadataMapper.getStageValue(context, MalariaStage.GAMETOCYTE))
+    }
 }

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataMapperTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataMapperTest.kt
@@ -2,32 +2,26 @@ package net.aiscope.gdd_app.presentation
 
 import android.content.Context
 import com.nhaarman.mockito_kotlin.whenever
-import kotlinx.coroutines.ExperimentalCoroutinesApi
-import net.aiscope.gdd_app.CoroutineTestRule
 import net.aiscope.gdd_app.R
 import net.aiscope.gdd_app.model.MalariaSpecies
 import net.aiscope.gdd_app.model.MalariaStage
+import net.aiscope.gdd_app.model.SampleMetadata
 import net.aiscope.gdd_app.model.SmearType
 import net.aiscope.gdd_app.ui.metadata.MetadataMapper
 import org.junit.Assert.assertEquals
 import org.junit.Before
-import org.junit.Rule
 import org.junit.Test
 import org.junit.runner.RunWith
 import org.mockito.Mock
 import org.mockito.junit.MockitoJUnitRunner
 
-@ExperimentalCoroutinesApi
 @RunWith(MockitoJUnitRunner::class)
 class MetadataMapperTest {
-    @get:Rule
-    var coroutinesTestRule = CoroutineTestRule()
-
     @Mock
     lateinit var context: Context
 
     @Before
-    fun before() = coroutinesTestRule.runBlockingTest {
+    fun before() {
         whenever(context.getString(R.string.malaria_species_p_falciparum))
             .thenReturn("P. falciparum")
         whenever(context.getString(R.string.malaria_species_p_vivax))
@@ -50,22 +44,19 @@ class MetadataMapperTest {
     }
 
     @Test
-    fun shouldReturnSmearType() =
-        coroutinesTestRule.runBlockingTest {
+    fun shouldReturnSmearType() {
             assertEquals(SmearType.THICK, MetadataMapper.getSmearType(R.id.metadata_blood_smear_thick))
             assertEquals(SmearType.THIN, MetadataMapper.getSmearType(R.id.metadata_blood_smear_thin))
         }
 
     @Test
-    fun shouldReturnSmearTypeId() =
-        coroutinesTestRule.runBlockingTest {
-            assertEquals(R.id.metadata_blood_smear_thick, MetadataMapper.getSmearTypeId(SmearType.THICK))
-            assertEquals(R.id.metadata_blood_smear_thin, MetadataMapper.getSmearTypeId(SmearType.THIN))
+    fun shouldReturnSmearTypeId() {
+            assertEquals(R.id.metadata_blood_smear_thick, MetadataMapper.getSmearTypeId(SampleMetadata(smearType = SmearType.THICK)))
+            assertEquals(R.id.metadata_blood_smear_thin, MetadataMapper.getSmearTypeId(SampleMetadata(smearType = SmearType.THIN)))
         }
 
     @Test
-    fun shouldReturnSpecies() =
-        coroutinesTestRule.runBlockingTest {
+    fun shouldReturnSpecies() {
             assertEquals(MalariaSpecies.P_FALCIPARUM, MetadataMapper.getSpecies(context,"P. falciparum"))
             assertEquals(MalariaSpecies.P_VIVAX, MetadataMapper.getSpecies(context,"P. vivax"))
             assertEquals(MalariaSpecies.P_OVALE, MetadataMapper.getSpecies(context,"P. ovale"))
@@ -74,18 +65,16 @@ class MetadataMapperTest {
         }
 
     @Test
-    fun shouldReturnSpeciesValue() =
-        coroutinesTestRule.runBlockingTest {
-            assertEquals("P. falciparum", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_FALCIPARUM))
-            assertEquals("P. vivax", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_VIVAX))
-            assertEquals("P. ovale", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_OVALE))
-            assertEquals("P. malariae", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_MALARIAE))
-            assertEquals("P. knowlesi", MetadataMapper.getSpeciesValue(context, MalariaSpecies.P_KNOWLESI))
+    fun shouldReturnSpeciesValue() {
+            assertEquals("P. falciparum", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_FALCIPARUM)))
+            assertEquals("P. vivax", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_VIVAX)))
+            assertEquals("P. ovale", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_OVALE)))
+            assertEquals("P. malariae", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_MALARIAE)))
+            assertEquals("P. knowlesi", MetadataMapper.getSpeciesValue(context, SampleMetadata(species = MalariaSpecies.P_KNOWLESI)))
         }
 
     @Test
-    fun shouldReturnStage() =
-        coroutinesTestRule.runBlockingTest {
+    fun shouldReturnStage() {
             assertEquals(MalariaStage.RING, MetadataMapper.getStage(context, "Ring"))
             assertEquals(MalariaStage.TROPHOZOITE, MetadataMapper.getStage(context, "Trophozoite"))
             assertEquals(MalariaStage.SCHIZONT, MetadataMapper.getStage(context, "Schizont"))
@@ -93,11 +82,10 @@ class MetadataMapperTest {
         }
 
     @Test
-    fun shouldReturnStageValue() =
-        coroutinesTestRule.runBlockingTest {
-            assertEquals("Ring", MetadataMapper.getStageValue(context, MalariaStage.RING))
-            assertEquals("Trophozoite", MetadataMapper.getStageValue(context, MalariaStage.TROPHOZOITE))
-            assertEquals("Schizont", MetadataMapper.getStageValue(context, MalariaStage.SCHIZONT))
-            assertEquals("Gametocyte", MetadataMapper.getStageValue(context, MalariaStage.GAMETOCYTE))
+    fun shouldReturnStageValue() {
+            assertEquals("Ring", MetadataMapper.getStageValue(context, SampleMetadata(stage = MalariaStage.RING)))
+            assertEquals("Trophozoite", MetadataMapper.getStageValue(context, SampleMetadata(stage = MalariaStage.TROPHOZOITE)))
+            assertEquals("Schizont", MetadataMapper.getStageValue(context, SampleMetadata(stage = MalariaStage.SCHIZONT)))
+            assertEquals("Gametocyte", MetadataMapper.getStageValue(context, SampleMetadata(stage = MalariaStage.GAMETOCYTE)))
         }
 }

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataPresenterTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataPresenterTest.kt
@@ -8,6 +8,7 @@ import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import net.aiscope.gdd_app.CoroutineTestRule
+import net.aiscope.gdd_app.R
 import net.aiscope.gdd_app.model.MalariaSpecies
 import net.aiscope.gdd_app.model.MalariaStage
 import net.aiscope.gdd_app.model.Sample
@@ -64,6 +65,12 @@ class MetadataPresenterTest {
         )
 
         repository.current()
+
+        whenever(context.getString(R.string.malaria_species_p_ovale))
+            .thenReturn("P. ovale")
+
+        whenever(context.getString(R.string.malaria_stage_trophozoite))
+            .thenReturn("Trophozoite")
     }
 
     @Test
@@ -91,11 +98,9 @@ class MetadataPresenterTest {
 
     @Test
     fun shouldDefaultToLastMetadata() = coroutinesTestRule.runBlockingTest{
-        val expectedMetadata = SampleMetadata(
-            SmearType.THIN,
-            MalariaSpecies.P_OVALE,
-            MalariaStage.TROPHOZOITE
-        )
+        val expectedSmearType = R.id.metadata_blood_smear_thin
+        val expectedSpecies = "P. ovale"
+        val expectedStage = "Trophozoite"
 
         whenever(repository.last()).thenReturn(
             Sample(
@@ -105,14 +110,20 @@ class MetadataPresenterTest {
                 images = linkedSetOf(),
                 disease = "malaria",
                 createdOn = java.util.Calendar.getInstance(),
-                metadata = expectedMetadata
+                metadata = SampleMetadata(
+                    SmearType.THIN,
+                    MalariaSpecies.P_OVALE,
+                    MalariaStage.TROPHOZOITE
+                )
             )
         )
 
         argumentCaptor<ViewStateModel>().apply{
             subject.showScreen()
             verify(view).fillForm(capture())
-            assertEquals(allValues[0].sampleMetadata, expectedMetadata)
+            assertEquals(expectedSmearType, allValues[0].smearType)
+            assertEquals(expectedSpecies, allValues[0].species)
+            assertEquals(expectedStage, allValues[0].stage)
         }
     }
 }

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataPresenterTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataPresenterTest.kt
@@ -2,6 +2,7 @@ package net.aiscope.gdd_app.presentation
 
 import android.content.Context
 import com.nhaarman.mockito_kotlin.any
+import com.nhaarman.mockito_kotlin.argumentCaptor
 import com.nhaarman.mockito_kotlin.check
 import com.nhaarman.mockito_kotlin.verify
 import com.nhaarman.mockito_kotlin.whenever
@@ -16,6 +17,7 @@ import net.aiscope.gdd_app.network.RemoteStorage
 import net.aiscope.gdd_app.repository.SampleRepository
 import net.aiscope.gdd_app.ui.metadata.MetadataPresenter
 import net.aiscope.gdd_app.ui.metadata.MetadataView
+import net.aiscope.gdd_app.ui.metadata.ViewStateModel
 import org.junit.Assert.assertEquals
 import org.junit.Before
 import org.junit.Rule
@@ -85,5 +87,32 @@ class MetadataPresenterTest {
         verify(repository).store(check {
             assertEquals(it.metadata, expected)
         })
+    }
+
+    @Test
+    fun shouldDefaultToLastMetadata() = coroutinesTestRule.runBlockingTest{
+        val expectedMetadata = SampleMetadata(
+            SmearType.THIN,
+            MalariaSpecies.P_OVALE,
+            MalariaStage.TROPHOZOITE
+        )
+
+        whenever(repository.last()).thenReturn(
+            Sample(
+                id = "idlast",
+                healthFacility = "StPau",
+                microscopist = "a microscopist",
+                images = linkedSetOf(),
+                disease = "malaria",
+                createdOn = java.util.Calendar.getInstance(),
+                metadata = expectedMetadata
+            )
+        )
+
+        argumentCaptor<ViewStateModel>().apply{
+            subject.showScreen()
+            verify(view).fillForm(capture())
+            assertEquals(allValues[0].sampleMetadata, expectedMetadata)
+        }
     }
 }

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataPresenterTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataPresenterTest.kt
@@ -16,6 +16,7 @@ import net.aiscope.gdd_app.model.SampleMetadata
 import net.aiscope.gdd_app.model.SmearType
 import net.aiscope.gdd_app.network.RemoteStorage
 import net.aiscope.gdd_app.repository.SampleRepository
+import net.aiscope.gdd_app.ui.metadata.MetadataMapper
 import net.aiscope.gdd_app.ui.metadata.MetadataPresenter
 import net.aiscope.gdd_app.ui.metadata.MetadataView
 import net.aiscope.gdd_app.ui.metadata.ViewStateModel
@@ -48,6 +49,8 @@ class MetadataPresenterTest {
     @Mock
     lateinit var context: Context
 
+    @Mock
+    lateinit var metadataMapper: MetadataMapper
 
     @InjectMocks
     lateinit var subject: MetadataPresenter
@@ -66,13 +69,17 @@ class MetadataPresenterTest {
 
         repository.current()
 
-        whenever(context.getString(R.string.malaria_species_p_ovale))
+        whenever(metadataMapper.getSmearType(R.id.metadata_blood_smear_thick))
+            .thenReturn(SmearType.THICK)
+        whenever(metadataMapper.getSmearTypeId(SmearType.THIN))
+            .thenReturn(R.id.metadata_blood_smear_thin)
+        whenever(metadataMapper.getSpecies(context, "P. vivax"))
+            .thenReturn(MalariaSpecies.P_VIVAX)
+        whenever(metadataMapper.getSpeciesValue(context, MalariaSpecies.P_OVALE))
             .thenReturn("P. ovale")
-
-        whenever(context.getString(R.string.malaria_species_p_vivax))
-            .thenReturn("P. vivax")
-
-        whenever(context.getString(R.string.malaria_stage_trophozoite))
+        whenever(metadataMapper.getStage(context, "Trophozoite"))
+            .thenReturn(MalariaStage.TROPHOZOITE)
+        whenever(metadataMapper.getStageValue(context, MalariaStage.TROPHOZOITE))
             .thenReturn("Trophozoite")
     }
 

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataPresenterTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/MetadataPresenterTest.kt
@@ -69,6 +69,9 @@ class MetadataPresenterTest {
         whenever(context.getString(R.string.malaria_species_p_ovale))
             .thenReturn("P. ovale")
 
+        whenever(context.getString(R.string.malaria_species_p_vivax))
+            .thenReturn("P. vivax")
+
         whenever(context.getString(R.string.malaria_stage_trophozoite))
             .thenReturn("Trophozoite")
     }
@@ -86,7 +89,7 @@ class MetadataPresenterTest {
             MalariaStage.TROPHOZOITE
         )
 
-        subject.save(SmearType.THICK, MalariaSpecies.P_VIVAX, MalariaStage.TROPHOZOITE)
+        subject.save(R.id.metadata_blood_smear_thick, "P. vivax", "Trophozoite")
 
         verify(remote).enqueue(check {
             assertEquals(it.metadata, expected)
@@ -121,9 +124,9 @@ class MetadataPresenterTest {
         argumentCaptor<ViewStateModel>().apply{
             subject.showScreen()
             verify(view).fillForm(capture())
-            assertEquals(expectedSmearType, allValues[0].smearType)
-            assertEquals(expectedSpecies, allValues[0].species)
-            assertEquals(expectedStage, allValues[0].stage)
+            assertEquals(expectedSmearType, allValues[0].smearTypeId)
+            assertEquals(expectedSpecies, allValues[0].speciesValue)
+            assertEquals(expectedStage, allValues[0].stageValue)
         }
     }
 }


### PR DESCRIPTION
Story: Metadata - keep last selected by user
AC: When the microscopist accesses the app the second time, the Smear Type, Species and Stage that the user selected the last time are shown as default values.

Added a createdOn field to the Sample in order to determine which was the last Sample created. This only looks at Samples that are completed (not incomplete). Since createdOn is new this functionality will only work once a Sample has been created (and completed) with the updated code.