### PR TITLE
Crash fix

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId "net.aiscope.gdd_app"
         minSdkVersion 23
         targetSdkVersion 29
-        versionCode 15
-        versionName "1.8.0"
+        versionCode 16
+        versionName "1.8.1"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigString 'SMARTLOOK_API_KEY', buildProperties.secrets['SMARTLOOK_API_KEY'].or(buildProperties.env['SMARTLOOK_API_KEY']).or("")

--- a/app/src/main/java/net/aiscope/gdd_app/repository/SampleDtos.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/repository/SampleDtos.kt
@@ -1,5 +1,6 @@
 package net.aiscope.gdd_app.repository
 
+import com.google.gson.annotations.SerializedName
 import net.aiscope.gdd_app.extensions.toLinkedHashSet
 import net.aiscope.gdd_app.model.MalariaSpecies
 import net.aiscope.gdd_app.model.MicroscopeQuality
@@ -13,17 +14,17 @@ import java.io.File
 import java.util.Calendar
 
 data class SampleDto(
-    val id: String,
-    val healthFacility: String,
-    val microscopist: String,
-    val disease: String? = null,
-    val preparation: SamplePreparationDto?,
-    val microscopeQuality: MicroscopeQualityDto?,
-    val imagePaths: List<String>,
-    val maskPaths: List<String>,
-    val metadata: SampleMetadataDto,
-    val status: Short,
-    val createdOn: Calendar? = null
+    @SerializedName("id") val id: String,
+    @SerializedName("healthFacility") val healthFacility: String,
+    @SerializedName("microscopist") val microscopist: String,
+    @SerializedName("disease") val disease: String? = null,
+    @SerializedName("preparation") val preparation: SamplePreparationDto?,
+    @SerializedName("microscopeQuality") val microscopeQuality: MicroscopeQualityDto?,
+    @SerializedName("imagePaths") val imagePaths: List<String>,
+    @SerializedName("maskPaths") val maskPaths: List<String>,
+    @SerializedName("metadata") val metadata: SampleMetadataDto,
+    @SerializedName("status") val status: Short,
+    @SerializedName("createdOn") val createdOn: Calendar? = null
 ) {
     fun toDomain(): Sample = Sample(
         id = id,
@@ -41,12 +42,12 @@ data class SampleDto(
 }
 
 data class SamplePreparationDto(
-    val waterType: Int,
-    val usesGiemsa: Boolean,
-    val giemsaFP: Boolean,
-    val usesPbs: Boolean,
-    val usesAlcohol: Boolean,
-    val reusesSlides: Boolean
+    @SerializedName("waterType") val waterType: Int,
+    @SerializedName("usesGiemsa") val usesGiemsa: Boolean,
+    @SerializedName("giemsaFP") val giemsaFP: Boolean,
+    @SerializedName("usesPbs") val usesPbs: Boolean,
+    @SerializedName("usesAlcohol") val usesAlcohol: Boolean,
+    @SerializedName("reusesSlides") val reusesSlides: Boolean
 ) {
     fun toDomain() = SamplePreparation(
         WaterType.values().first { it.id == waterType },
@@ -59,8 +60,8 @@ data class SamplePreparationDto(
 }
 
 data class MicroscopeQualityDto(
-    val isDamaged: Boolean,
-    val magnification: Int
+    @SerializedName("isDamaged") val isDamaged: Boolean,
+    @SerializedName("magnification") val magnification: Int
 ) {
     fun toDomain() = MicroscopeQuality(
         isDamaged,
@@ -69,8 +70,8 @@ data class MicroscopeQualityDto(
 }
 
 data class SampleMetadataDto(
-    val bloodType: Int,
-    val species: Int
+    @SerializedName("bloodType") val bloodType: Int,
+    @SerializedName("species") val species: Int
 ) {
     fun toDomain() = SampleMetadata(
         SmearType.values().first { it.id == this.bloodType },

--- a/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
@@ -46,8 +46,10 @@ class SampleRepositorySharedPreference @Inject constructor(
         val jsons = store.all().filter { it != "true" }
 
         return jsons.map {
-            gson.fromJson<SampleDto>(it).toDomain()
-        }.toList()
+            kotlin.runCatching {
+                gson.fromJson<SampleDto>(it).toDomain()
+            }.getOrNull()
+        }.filterNotNull()
     }
 
     override suspend fun last(): Sample? {


### PR DESCRIPTION
Caused by having the `SampleDto`'s field names obfuscated. 
Fixed by using `@SerializedName` annotation on the fields.
Also filters out existing malformed data.

Stacktrace: 
```
Fatal Exception: com.google.gson.JsonSyntaxException: java.lang.IllegalStateException: Expected a string but was BEGIN_ARRAY at line 1 column 80 path $.d
       at com.google.gson.internal.bind.ReflectiveTypeAdapterFactory$Adapter.read(ReflectiveTypeAdapterFactory.java:224)
       at com.google.gson.Gson.fromJson(Gson.java:887)
       at com.google.gson.Gson.fromJson(Gson.java:852)
       at com.google.gson.Gson.fromJson(Gson.java:801)
       at net.aiscope.gdd_app.repository.SampleRepositorySharedPreference.all(SampleRepositorySharedPreference.java:75)
       at net.aiscope.gdd_app.repository.SampleRepositorySharedPreference.last(SampleRepositorySharedPreference.java:54)
       at net.aiscope.gdd_app.ui.sample_preparation.SamplePreparationPresenter.showScreen(SamplePreparationPresenter.java:16)
       at net.aiscope.gdd_app.ui.sample_preparation.SamplePreparationActivity$onCreate$1.invokeSuspend(SamplePreparationActivity.java:44)
       at kotlin.coroutines.jvm.internal.BaseContinuationImpl.resumeWith(BaseContinuationImpl.java:33)
       at kotlinx.coroutines.DispatchedContinuationKt.resumeCancellableWith(DispatchedContinuationKt.java:330)
       at kotlinx.coroutines.intrinsics.CancellableKt.startCoroutineCancellable(CancellableKt.java:26)
       at kotlinx.coroutines.CoroutineStart.invoke(CoroutineStart.java:109)
       at kotlinx.coroutines.AbstractCoroutine.start(AbstractCoroutine.java:158)
       at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch(BuildersKt__Builders_commonKt.java:54)
       at kotlinx.coroutines.BuildersKt.launch(BuildersKt.java:1)
       at kotlinx.coroutines.BuildersKt__Builders_commonKt.launch$default(BuildersKt__Builders_commonKt.java:47)
       at kotlinx.coroutines.BuildersKt.launch$default(BuildersKt.java:1)
       at net.aiscope.gdd_app.ui.sample_preparation.SamplePreparationActivity.onCreate(SamplePreparationActivity.java:43)
       at android.app.Activity.performCreate(Activity.java:7224)
       at android.app.Activity.performCreate(Activity.java:7213)
       at android.app.Instrumentation.callActivityOnCreate(Instrumentation.java:1272)
       at android.app.ActivityThread.performLaunchActivity(ActivityThread.java:2956)
       at android.app.ActivityThread.handleLaunchActivity(ActivityThread.java:3113)
       at android.app.servertransaction.LaunchActivityItem.execute(LaunchActivityItem.java:78)
       at android.app.servertransaction.TransactionExecutor.executeCallbacks(TransactionExecutor.java:113)
       at android.app.servertransaction.TransactionExecutor.execute(TransactionExecutor.java:71)
       at android.app.ActivityThread$H.handleMessage(ActivityThread.java:1858)
       at android.os.Handler.dispatchMessage(Handler.java:106)
       at android.os.Looper.loop(Looper.java:201)
       at android.app.ActivityThread.main(ActivityThread.java:6820)
       at java.lang.reflect.Method.invoke(Method.java)
       at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:547)
       at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:922)
```