### PR TITLE
Smoother drawing + points

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -23,8 +23,8 @@ android {
         applicationId "net.aiscope.gdd_app"
         minSdkVersion 23
         targetSdkVersion 29
-        versionCode 16
-        versionName "1.8.1"
+        versionCode 17
+        versionName "1.8.2"
         testInstrumentationRunner "androidx.test.runner.AndroidJUnitRunner"
 
         buildConfigString 'SMARTLOOK_API_KEY', buildProperties.secrets['SMARTLOOK_API_KEY'].or(buildProperties.env['SMARTLOOK_API_KEY']).or("")

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomView.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomView.kt
@@ -34,7 +34,7 @@ class MaskCustomView @JvmOverloads constructor(
     }
 
     var onMaskingActionFinishedListener: OnTouchListener? = null
-    private val maskLayer = MaskLayer(context, imageMatrix)
+    private val maskLayer = MaskLayer(imageMatrix)
     private var currentMode: Mode = Mode.Draw
     private lateinit var drawableSize: Size
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -204,15 +204,7 @@ class MaskLayer(private val imageMatrix: Matrix) {
     }
 
     fun drawMove(x: Float, y: Float) {
-        currentPath?.run {
-            val (latestX, latestY) = latestPoint
-            val dX = abs(x - latestX)
-            val dY = abs(y - latestY)
-            val touchTolerance = ViewConfiguration.get(context).scaledTouchSlop / currentScale
-            if (dX >= touchTolerance || dY >= touchTolerance) {
-                quadTo(x, y)
-            }
-        }
+        currentPath?.quadTo(x, y)
     }
 
     fun drawEnd() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -1,6 +1,5 @@
 package net.aiscope.gdd_app.ui.mask.customview
 
-import android.content.Context
 import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Color
@@ -10,16 +9,11 @@ import android.graphics.PorterDuff
 import android.graphics.PorterDuffXfermode
 import android.os.Parcelable
 import android.util.Size
-import android.view.ViewConfiguration
 import androidx.core.graphics.withMatrix
 import java.util.*
-import kotlin.math.abs
 
 @Suppress("TooManyFunctions")
-class MaskLayer(
-    private val context: Context,
-    private val imageMatrix: Matrix
-) {
+class MaskLayer(private val imageMatrix: Matrix) {
     companion object {
         private const val ALPHA_OPAQUE = 0xFF
         private const val MASK_PAINT_OPACITY = .8
@@ -141,10 +135,16 @@ class MaskLayer(
             val (path, paint) = pathsAndPaints[i]
             val paintReviewed =
                 if (removeAlpha) Paint(paint).apply { alpha = ALPHA_OPAQUE } else paint
-            canvas.drawPath(path, paintReviewed)
+            path.draw(canvas, paintReviewed)
         }
-        currentPath?.let {
-            canvas.drawPath(it, currentPaint)
+        currentPath?.draw(canvas, currentPaint)
+    }
+
+    private fun PointToPointPath.draw(canvas: Canvas, paint: Paint) {
+        if (!hasMultiplePoints()) {
+            canvas.drawPoint(firstPoint.first, firstPoint.second, paint)
+        } else {
+            canvas.drawPath(this, paint)
         }
     }
 
@@ -217,9 +217,7 @@ class MaskLayer(
 
     fun drawEnd() {
         currentPath?.run {
-            val visibleChange: Boolean =
-                if (isCurrentModeDraw()) hasMultiplePoints()
-                else !latestChangeBitmap.sameAs(currentStateBitmap)
+            val visibleChange: Boolean = !latestChangeBitmap.sameAs(currentStateBitmap)
             if (visibleChange) {
                 keepLatestChangeBitmap()
                 flushPendingUndos()

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -209,8 +209,7 @@ class MaskLayer(private val imageMatrix: Matrix) {
 
     fun drawEnd() {
         currentPath?.run {
-            val visibleChange: Boolean = !latestChangeBitmap.sameAs(currentStateBitmap)
-            if (visibleChange) {
+            if (!latestChangeBitmap.sameAs(currentStateBitmap)) {
                 keepLatestChangeBitmap()
                 flushPendingUndos()
                 pathsAndPaints.add(PathAndPaint(this, currentPaint))

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/PointToPointPath.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/PointToPointPath.kt
@@ -5,9 +5,10 @@ import java.util.*
 
 class PointToPointPath(x: Float, y: Float) : Path() {
 
-    val points: List<Pair<Float, Float>> = LinkedList()
-    val firstPoint: Pair<Float, Float> = x to y
-    var latestPoint: Pair<Float, Float> = firstPoint
+    internal val points: List<Pair<Float, Float>> = LinkedList()
+    internal val firstPoint: Pair<Float, Float> = x to y
+
+    private var latestPoint: Pair<Float, Float> = firstPoint
 
     init {
         moveTo(x, y)
@@ -15,7 +16,6 @@ class PointToPointPath(x: Float, y: Float) : Path() {
     }
 
     constructor(points: List<Pair<Float, Float>>) : this(points[0].first, points[0].second) {
-        require(points.size > 1)
         for ((x, y) in points.subList(1, points.size)) {
             quadTo(x, y)
         }


### PR DESCRIPTION
The changes in this PR allows single points to be drawn.

Also, it makes drawing smoother by registering all moves, including the ones smaller than `ViewConfiguration.scaledTouchSlop` (this should be used only for scrolling, I mistakenly added it in the past for drawing).

| Before | After |
|--------|-------|
| ![before](https://user-images.githubusercontent.com/2426348/84601474-a970a480-ae80-11ea-84a0-f2a72ffa48f0.gif) | ![after](https://user-images.githubusercontent.com/2426348/84601414-294a3f00-ae80-11ea-92ce-732c38bb08b9.gif) |
