### PR TITLE
[136] Edit existing labels

### DIFF
--- a/app/src/main/java/net/aiscope/gdd_app/dagger/PrivacyPolicyModule.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/dagger/PrivacyPolicyModule.kt
@@ -2,9 +2,7 @@ package net.aiscope.gdd_app.dagger
 
 import dagger.Binds
 import dagger.Module
-import dagger.Provides
 import net.aiscope.gdd_app.ui.policy.PrivacyPolicyActivity
-import net.aiscope.gdd_app.ui.policy.PrivacyPolicyPresenter
 import net.aiscope.gdd_app.ui.policy.PrivacyPolicyView
 
 @Module

--- a/app/src/main/java/net/aiscope/gdd_app/extensions/BitmapExt.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/extensions/BitmapExt.kt
@@ -11,7 +11,7 @@ const val MAX_QUALITY = 100
 
 fun Bitmap.writeToFile(file: File) {
     val out = FileOutputStream(file)
-    this.compress(Bitmap.CompressFormat.JPEG, MAX_QUALITY, out)
+    this.compress(Bitmap.CompressFormat.PNG, MAX_QUALITY, out)
 }
 
 suspend fun Bitmap.writeToFileAsync(file: File) = withContext(Dispatchers.IO) {

--- a/app/src/main/java/net/aiscope/gdd_app/network/FirebaseRemoteStorage.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/network/FirebaseRemoteStorage.kt
@@ -11,11 +11,11 @@ class FirebaseRemoteStorage(private val uploader: FirebaseStorageUploader, priva
         uploader.upload(gson.toJson(sample.toDto()), jsonKey)
 
         sample.images.forEachIndexed { index, image ->
-            uploader.upload(image, "${sample.id}/image_${index}.jpg")
+            uploader.upload(image, "${sample.id}/image_${index}.png")
         }
 
         sample.masks.forEachIndexed { index, mask ->
-            uploader.upload(mask, "${sample.id}/mask_${index}.jpg")
+            uploader.upload(mask, "${sample.id}/mask_${index}.png")
         }
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/network/SampleDtos.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/network/SampleDtos.kt
@@ -8,7 +8,6 @@ import net.aiscope.gdd_app.model.Sample
 import net.aiscope.gdd_app.model.SampleMetadata
 import net.aiscope.gdd_app.model.SamplePreparation
 import java.text.SimpleDateFormat
-import java.util.Calendar
 
 val ISO_FORMAT = SimpleDateFormat("yyyy-MM-dd'T'HH:mm:ssZ")
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/CaptureFlow.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/CaptureFlow.kt
@@ -12,18 +12,22 @@ interface CaptureFlow
 fun <T> T.attachCaptureFlowToolbar(toolbar: androidx.appcompat.widget.Toolbar)
         where T : AppCompatActivity, T : CaptureFlow {
     toolbar.setNavigationOnClickListener {
-        with(AlertDialog.Builder(this, R.style.AppTheme_Dialog)) {
-            setPositiveButton(R.string.capture_flow_exit_dialog_exit) { _, _ ->
-                goToHome()
-            }
-            setNegativeButton(R.string.capture_flow_exit_dialog_stay) { _, _ ->
-                // do nothing
-            }
-            setMessage(getString(R.string.capture_flow_exit_dialog_message))
-            setTitle(getText(R.string.capture_flow_exit_dialog_title))
-            create()
-        }.show()
+        showConfirmExitDialog()
     }
+}
+
+fun <T> T.showConfirmExitDialog() where T : AppCompatActivity, T : CaptureFlow {
+    with(AlertDialog.Builder(this, R.style.AppTheme_Dialog)) {
+        setPositiveButton(R.string.capture_flow_exit_dialog_exit) { _, _ ->
+            goToHome()
+        }
+        setNegativeButton(R.string.capture_flow_exit_dialog_stay) { _, _ ->
+            // do nothing
+        }
+        setMessage(getString(R.string.capture_flow_exit_dialog_message))
+        setTitle(getText(R.string.capture_flow_exit_dialog_title))
+        create()
+    }.show()
 }
 
 fun <T> T.goToHomeAndConfirmSaved() where T : AppCompatActivity, T : CaptureFlow {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImageActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImageActivity.kt
@@ -79,7 +79,7 @@ class CaptureImageActivity : AppCompatActivity(), CaptureImageView, CaptureFlow 
     override fun takePhoto(imageName: String, onPhotoReceived: suspend (File?) -> Unit) {
         capture_image_loading_modal.visibility = View.VISIBLE
         val result = fotoapparat.takePicture()
-        val dest = File(this.filesDir, "${imageName}.jpg")
+        val dest = File(this.filesDir, "${imageName}.png")
         result.toBitmap().whenAvailable {
             it?.let {
                 val degrees = (-it.rotationDegrees) % THREE_SIXTY_DEGREES

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
@@ -19,7 +19,7 @@ class CaptureImagePresenter(
                 val sample = repository.current().addImage(file)
                 repository.store(sample)
 
-                view.goToMask(sample.disease ?: "FAKE_DISEASE", file.absolutePath, sample.nextMaskName())
+                view.goToMask(sample.disease!!, file.absolutePath, sample.nextMaskName())
             }
         }
     }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
@@ -19,7 +19,7 @@ class CaptureImagePresenter(
                 val sample = repository.current().addImage(file)
                 repository.store(sample)
 
-                view.goToMask(sample.disease!!, file.absolutePath, sample.nextMaskName())
+                view.goToMask(sample.disease ?: "FAKE_DISEASE", file.absolutePath, sample.nextMaskName())
             }
         }
     }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/main/LogoutFLow.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/main/LogoutFLow.kt
@@ -7,7 +7,6 @@ import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.appcompat.widget.PopupMenu
 import net.aiscope.gdd_app.R
-import net.aiscope.gdd_app.ui.CaptureFlow
 
 interface LogoutFLow {
     fun logoutAction()

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
@@ -107,6 +107,8 @@ class MaskActivity : AppCompatActivity(), MaskView, CaptureFlow {
     override fun goToMetadata() {
         val intent = Intent(this, MetadataActivity::class.java)
         startActivity(intent)
+        //Finish the activity to avoid keeping all the bitmaps in memory
+        finish()
     }
 
     override fun notifyImageCouldNotBeTaken() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
@@ -181,7 +181,6 @@ class MaskActivity : AppCompatActivity(), MaskView, CaptureFlow {
         val options = BitmapFactory.Options()
         options.inPreferredConfig = Bitmap.Config.ARGB_8888
         options.inMutable = true
-
         BitmapFactory.decodeFile(filepath, options)
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
@@ -3,7 +3,6 @@ package net.aiscope.gdd_app.ui.mask
 import android.content.Intent
 import android.graphics.Bitmap
 import android.graphics.BitmapFactory
-import android.graphics.drawable.Drawable
 import android.graphics.drawable.LayerDrawable
 import android.os.Bundle
 import android.view.Gravity

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
@@ -180,5 +180,4 @@ class MaskActivity : AppCompatActivity(), MaskView, CaptureFlow {
         //Converts to a mutable bitmap
         bitmap.copy(Bitmap.Config.ARGB_8888, true)
     }
-
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
@@ -178,7 +178,7 @@ class MaskActivity : AppCompatActivity(), MaskView, CaptureFlow {
 
     private suspend fun readMask(filepath: String): Bitmap? = withContext(Dispatchers.IO) {
         val bitmap = BitmapFactory.decodeFile(filepath)
-        //FIXME: Should be a better way to get a mutable map
+        //FIXME: Should be a better way to get a mutable bitmap
         bitmap.copy(Bitmap.Config.ARGB_8888, true)
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
@@ -177,7 +177,7 @@ class MaskActivity : AppCompatActivity(), MaskView, CaptureFlow {
 
     private suspend fun readMask(filepath: String): Bitmap? = withContext(Dispatchers.IO) {
         val bitmap = BitmapFactory.decodeFile(filepath)
-        //FIXME: Should be a better way to get a mutable bitmap
+        //Converts to a mutable bitmap
         bitmap.copy(Bitmap.Config.ARGB_8888, true)
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
@@ -120,8 +120,8 @@ class MaskActivity : AppCompatActivity(), MaskView, CaptureFlow {
             photo_mask_view.setImageBitmap(bmp)
 
             maskPath?.let {
-                var draw = readMask(maskPath)
-                draw?.let {  photo_mask_view.setMaskBitmap(draw) }
+                val mask = readMask(maskPath)
+                mask?.let {  photo_mask_view.setMaskBitmap(it) }
             }
         }
     }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskActivity.kt
@@ -122,7 +122,7 @@ class MaskActivity : AppCompatActivity(), MaskView, CaptureFlow {
             photo_mask_view.setImageBitmap(bmp)
 
             maskPath?.let {
-                val mask = readMask(maskPath)
+                val mask = readMutableImage(maskPath)
                 mask?.let {  photo_mask_view.setMaskBitmap(it) }
             }
         }
@@ -177,9 +177,11 @@ class MaskActivity : AppCompatActivity(), MaskView, CaptureFlow {
         BitmapFactory.decodeFile(filepath, options)
     }
 
-    private suspend fun readMask(filepath: String): Bitmap? = withContext(Dispatchers.IO) {
-        val bitmap = BitmapFactory.decodeFile(filepath)
-        //Converts to a mutable bitmap
-        bitmap.copy(Bitmap.Config.ARGB_8888, true)
+    private suspend fun readMutableImage(filepath: String): Bitmap = withContext(Dispatchers.IO) {
+        val options = BitmapFactory.Options()
+        options.inPreferredConfig = Bitmap.Config.ARGB_8888
+        options.inMutable = true
+
+        BitmapFactory.decodeFile(filepath, options)
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskPresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskPresenter.kt
@@ -32,9 +32,9 @@ class MaskPresenter(
         }
     }
 
-    fun start(diseaseName: String, imagePath: String) {
+    fun start(diseaseName: String, imagePath: String, maskPath: String?) {
         this.diseaseName = diseaseName
-        view.initPhotoMaskView(imagePath)
+        view.initPhotoMaskView(imagePath, maskPath)
     }
 
     companion object {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskView.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/MaskView.kt
@@ -7,5 +7,5 @@ interface MaskView {
     fun takeMask(maskName: String, onPhotoReceived: suspend (File?) -> Unit)
     fun goToMetadata()
     fun notifyImageCouldNotBeTaken()
-    fun initPhotoMaskView(imagePath: String)
+    fun initPhotoMaskView(imagePath: String, maskPath: String?)
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomView.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomView.kt
@@ -2,6 +2,7 @@ package net.aiscope.gdd_app.ui.mask.customview
 
 import android.annotation.SuppressLint
 import android.content.Context
+import android.graphics.Bitmap
 import android.graphics.Canvas
 import android.graphics.Matrix
 import android.graphics.drawable.Drawable
@@ -35,6 +36,7 @@ class MaskCustomView @JvmOverloads constructor(
 
     var onMaskingActionFinishedListener: OnTouchListener? = null
     private val maskLayer = MaskLayer(imageMatrix)
+
     private var currentMode: Mode = Mode.Draw
     private lateinit var drawableSize: Size
 
@@ -136,6 +138,10 @@ class MaskCustomView @JvmOverloads constructor(
         maskLayer.setBrushColor(color)
 
     fun getMaskBitmap() = maskLayer.getBitmap()
+
+    fun setMaskBitmap(bitmap: Bitmap) {
+        maskLayer.setMaskBitmap(bitmap)
+    }
 
     fun undo() {
         maskLayer.undo()

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomView.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomView.kt
@@ -141,6 +141,7 @@ class MaskCustomView @JvmOverloads constructor(
 
     fun setMaskBitmap(bitmap: Bitmap) {
         maskLayer.setMaskBitmap(bitmap)
+        invalidate()
     }
 
     fun undo() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomView.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomView.kt
@@ -36,7 +36,6 @@ class MaskCustomView @JvmOverloads constructor(
 
     var onMaskingActionFinishedListener: OnTouchListener? = null
     private val maskLayer = MaskLayer(imageMatrix)
-
     private var currentMode: Mode = Mode.Draw
     private lateinit var drawableSize: Size
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -212,7 +212,6 @@ class MaskLayer(private val imageMatrix: Matrix) {
     }
 
     fun drawEnd() {
-        //So this is when it all suddenly shows?
         currentPath?.run {
             if (!latestChangeBitmap.sameAs(currentStateBitmap)) {
                 keepLatestChangeBitmap()

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -209,7 +209,8 @@ class MaskLayer(private val imageMatrix: Matrix) {
 
         return backgroundBitMap.apply {
             val canvas = Canvas(this)
-            drawPaths(canvas, removeAlpha = true) }
+            drawPaths(canvas, removeAlpha = true)
+        }
     }
 
     fun drawStart(x: Float, y: Float) {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -202,7 +202,14 @@ class MaskLayer(private val imageMatrix: Matrix) {
     fun redoAvailable() = undoPendingPaths > 0
 
     fun getBitmap(): Bitmap {
-        return currentStateBitmap.apply { drawPaths(currentStateBitmapCanvas, removeAlpha = true) }
+        val backgroundBitMap = initialBitmap ?: Bitmap.createBitmap(
+            currentStateBitmap.width,
+            currentStateBitmap.height,
+            Bitmap.Config.ARGB_8888)
+
+        return backgroundBitMap.apply {
+            val canvas = Canvas(this)
+            drawPaths(canvas, removeAlpha = true) }
     }
 
     fun drawStart(x: Float, y: Float) {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -234,7 +234,7 @@ class MaskLayer(private val imageMatrix: Matrix) {
     private fun isCurrentModeDraw() = currentMode == Mode.Draw
 
     private fun keepLatestChangeBitmap() {
-        //latestChangeBitmap.eraseColor(Color.TRANSPARENT)
+        latestChangeBitmap.eraseColor(Color.TRANSPARENT)
         latestChangeBitmapCanvas.drawBitmap(currentStateBitmap, 0f, 0f, BITMAP_TRANSFER_PAINT)
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -19,6 +19,7 @@ class MaskLayer(private val imageMatrix: Matrix) {
         private const val MASK_PAINT_OPACITY = .8
         private const val PATH_STROKE_WIDTH = 80f
         private val BITMAP_TRANSFER_PAINT = Paint()
+        private val EMPTY_MATRIX = Matrix()
         val ERASER_XFER_MODE = PorterDuffXfermode(PorterDuff.Mode.CLEAR)
 
         fun newDefaultPaintBrush(color: Int, strokeWidth: Float) = Paint().apply {
@@ -113,7 +114,6 @@ class MaskLayer(private val imageMatrix: Matrix) {
     private fun sizeInitialized() = this::size.isInitialized
 
     private fun brushColorInitialized() = currentBrushColor != 0
-
     fun draw(canvas: Canvas) {
         if (!sizeInitialized()) return
 
@@ -129,9 +129,7 @@ class MaskLayer(private val imageMatrix: Matrix) {
     fun setMaskBitmap(bitmap: Bitmap){
         require(sizeInitialized()) { "Size was not initialized yet" }
         initialBitmap = bitmap
-        currentStateBitmap = Bitmap.createScaledBitmap(bitmap, size.width, size.height, false)
-        currentStateBitmapCanvas = Canvas(currentStateBitmap)
-        draw(currentStateBitmapCanvas)
+        currentStateBitmapCanvas.drawBitmap(bitmap, EMPTY_MATRIX, null)
     }
 
     private fun pathBeingDrawn() = currentPath != null
@@ -140,8 +138,7 @@ class MaskLayer(private val imageMatrix: Matrix) {
         currentStateBitmap.eraseColor(Color.TRANSPARENT)
 
         initialBitmap?.let{
-            currentStateBitmap = Bitmap.createScaledBitmap(it, size.width, size.height, false)
-            currentStateBitmapCanvas = Canvas(currentStateBitmap)
+            currentStateBitmapCanvas.drawBitmap(it, EMPTY_MATRIX, null)
         }
 
         drawPaths(currentStateBitmapCanvas)

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -139,9 +139,9 @@ class MaskLayer(private val imageMatrix: Matrix) {
     private fun composeCurrentStateBitmap() {
         currentStateBitmap.eraseColor(Color.TRANSPARENT)
 
-        //So it may make sense to just reset it to 'init' state instead of erasing???
         initialBitmap?.let{
             currentStateBitmap = Bitmap.createScaledBitmap(it, size.width, size.height, false)
+            currentStateBitmapCanvas = Canvas(currentStateBitmap)
         }
 
         drawPaths(currentStateBitmapCanvas)

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskLayer.kt
@@ -2,6 +2,7 @@ package net.aiscope.gdd_app.ui.mask.customview
 
 import android.graphics.Bitmap
 import android.graphics.Canvas
+import android.graphics.Color
 import android.graphics.Matrix
 import android.graphics.Paint
 import android.graphics.PorterDuff
@@ -64,6 +65,9 @@ class MaskLayer(private val imageMatrix: Matrix) {
         )
     }
     private val latestChangeBitmapCanvas by lazy { Canvas(latestChangeBitmap) }
+
+    private var initialBitmap :Bitmap? = null
+
     private lateinit var currentStateBitmap :Bitmap
 
     private lateinit var currentStateBitmapCanvas :Canvas
@@ -124,6 +128,7 @@ class MaskLayer(private val imageMatrix: Matrix) {
 
     fun setMaskBitmap(bitmap: Bitmap){
         require(sizeInitialized()) { "Size was not initialized yet" }
+        initialBitmap = bitmap
         currentStateBitmap = Bitmap.createScaledBitmap(bitmap, size.width, size.height, false)
         currentStateBitmapCanvas = Canvas(currentStateBitmap)
         draw(currentStateBitmapCanvas)
@@ -132,8 +137,12 @@ class MaskLayer(private val imageMatrix: Matrix) {
     private fun pathBeingDrawn() = currentPath != null
 
     private fun composeCurrentStateBitmap() {
-        //So this removes it all again??
-        //currentStateBitmap.eraseColor(Color.TRANSPARENT)
+        currentStateBitmap.eraseColor(Color.TRANSPARENT)
+
+        //So it may make sense to just reset it to 'init' state instead of erasing???
+        initialBitmap?.let{
+            currentStateBitmap = Bitmap.createScaledBitmap(it, size.width, size.height, false)
+        }
 
         drawPaths(currentStateBitmapCanvas)
     }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -62,6 +62,7 @@ class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
 
     override fun fillForm(model: ViewStateModel) {
         imagesAdapter.setImages(model.images)
+        imagesAdapter.setMasks(model.masks)
         model.smearTypeId?.let { metadata_section_smear_type_radio_group.check(it) }
         model.speciesValue?.let { metadata_species_spinner.select(it) }
     }
@@ -123,9 +124,9 @@ class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
         }
     }
 
-    private fun onImageClicked(index: Int) {
+    private fun onImageClicked(image: File, mask: File) {
         lifecycleScope.launch {
-            presenter.editImage(index)
+            presenter.editImage(image, mask)
         }
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -96,7 +96,7 @@ class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
         intent.putExtra(MaskActivity.EXTRA_IMAGE_NAME, image.absolutePath)
 
         //Doesn't seem to pick up on this
-        intent.putExtra(MaskActivity.EXTRA_MASK_NAME, mask.absolutePath)
+        intent.putExtra(MaskActivity.EXTRA_MASK_NAME, mask.name)
 
         startActivity(intent)
     }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -4,6 +4,7 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
+import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -18,6 +19,7 @@ import net.aiscope.gdd_app.ui.CaptureFlow
 import net.aiscope.gdd_app.ui.attachCaptureFlowToolbar
 import net.aiscope.gdd_app.ui.capture.CaptureImageActivity
 import net.aiscope.gdd_app.ui.goToHomeAndConfirmSaved
+import net.aiscope.gdd_app.ui.main.MainActivity
 import net.aiscope.gdd_app.ui.mask.MaskActivity
 import net.aiscope.gdd_app.ui.snackbar.CustomSnackbar
 import net.aiscope.gdd_app.ui.snackbar.CustomSnackbarAction
@@ -101,7 +103,27 @@ class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
 
         startActivity(intent)
     }
+    
+    override fun onBackPressed() {
+        with(AlertDialog.Builder(this, R.style.AppTheme_Dialog)) {
+            setPositiveButton(R.string.capture_flow_exit_dialog_exit) { _, _ ->
+                goToHome()
+            }
+            setNegativeButton(R.string.capture_flow_exit_dialog_stay) { _, _ ->
+                // do nothing
+            }
+            setMessage(getString(R.string.capture_flow_exit_dialog_message))
+            setTitle(getText(R.string.capture_flow_exit_dialog_title))
+            create()
+        }.show()
+    }
 
+    fun <T> T.goToHome() where T : AppCompatActivity, T : CaptureFlow {
+        val intent = Intent(this, MainActivity::class.java)
+        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
+        startActivity(intent)
+    }
+    
     private fun save() {
         lifecycleScope.launch {
             presenter.save(

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -26,6 +26,7 @@ import net.aiscope.gdd_app.ui.snackbar.CustomSnackbarAction
 import java.io.File
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
 
     @Inject
@@ -123,7 +124,7 @@ class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
         intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
         startActivity(intent)
     }
-    
+
     private fun save() {
         lifecycleScope.launch {
             presenter.save(

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -21,6 +21,7 @@ import net.aiscope.gdd_app.ui.capture.CaptureImageActivity
 import net.aiscope.gdd_app.ui.goToHome
 import net.aiscope.gdd_app.ui.goToHomeAndConfirmSaved
 import net.aiscope.gdd_app.ui.mask.MaskActivity
+import net.aiscope.gdd_app.ui.showConfirmExitDialog
 import net.aiscope.gdd_app.ui.snackbar.CustomSnackbar
 import net.aiscope.gdd_app.ui.snackbar.CustomSnackbarAction
 import java.io.File
@@ -106,17 +107,7 @@ class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
     }
     
     override fun onBackPressed() {
-        with(AlertDialog.Builder(this, R.style.AppTheme_Dialog)) {
-            setPositiveButton(R.string.capture_flow_exit_dialog_exit) { _, _ ->
-                goToHome()
-            }
-            setNegativeButton(R.string.capture_flow_exit_dialog_stay) { _, _ ->
-                // do nothing
-            }
-            setMessage(getString(R.string.capture_flow_exit_dialog_message))
-            setTitle(getText(R.string.capture_flow_exit_dialog_title))
-            create()
-        }.show()
+        showConfirmExitDialog()
     }
 
     private fun save() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -18,15 +18,19 @@ import net.aiscope.gdd_app.ui.CaptureFlow
 import net.aiscope.gdd_app.ui.attachCaptureFlowToolbar
 import net.aiscope.gdd_app.ui.capture.CaptureImageActivity
 import net.aiscope.gdd_app.ui.goToHomeAndConfirmSaved
+import net.aiscope.gdd_app.ui.mask.MaskActivity
 import net.aiscope.gdd_app.ui.snackbar.CustomSnackbar
 import net.aiscope.gdd_app.ui.snackbar.CustomSnackbarAction
+import java.io.File
 import javax.inject.Inject
 
-class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
+class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
 
-    @Inject lateinit var presenter: MetadataPresenter
+    @Inject
+    lateinit var presenter: MetadataPresenter
 
-    private val imagesAdapter = SampleImagesAdapter(lifecycleScope, this::onAddImageClicked)
+    private val imagesAdapter =
+        SampleImagesAdapter(lifecycleScope, this::onAddImageClicked, this::onImageClicked)
 
     override fun onCreate(savedInstanceState: Bundle?) {
         AndroidInjection.inject(this)
@@ -38,7 +42,8 @@ class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
 
         metadata_blood_sample_images.apply {
             setHasFixedSize(true)
-            layoutManager = LinearLayoutManager(this@MetadataActivity, LinearLayoutManager.HORIZONTAL, false)
+            layoutManager =
+                LinearLayoutManager(this@MetadataActivity, LinearLayoutManager.HORIZONTAL, false)
             adapter = imagesAdapter
         }
 
@@ -67,8 +72,8 @@ class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
         CustomSnackbar.make(
             findViewById(android.R.id.content),
             getString(R.string.metadata_snackbar_error),
-            Snackbar.LENGTH_INDEFINITE,null,
-            CustomSnackbarAction(getString(R.string.metadata_snackbar_retry),View.OnClickListener {
+            Snackbar.LENGTH_INDEFINITE, null,
+            CustomSnackbarAction(getString(R.string.metadata_snackbar_retry), View.OnClickListener {
                 save()
             })
         ).show()
@@ -82,6 +87,18 @@ class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
         val intent = Intent(this, CaptureImageActivity::class.java)
         intent.putExtra(CaptureImageActivity.EXTRA_IMAGE_NAME, nextImageName)
         this.startActivity(intent)
+    }
+
+    override fun editImage(disease: String, image: File, mask: File){
+        val intent = Intent(this, MaskActivity::class.java)
+        //FIXME: where do I get this??
+        intent.putExtra(MaskActivity.EXTRA_DISEASE_NAME, disease)
+        intent.putExtra(MaskActivity.EXTRA_IMAGE_NAME, image.absolutePath)
+
+        //Doesn't seem to pick up on this
+        intent.putExtra(MaskActivity.EXTRA_MASK_NAME, mask.absolutePath)
+
+        startActivity(intent)
     }
 
     private fun save() {
@@ -98,4 +115,11 @@ class MetadataActivity : AppCompatActivity() , MetadataView, CaptureFlow {
             presenter.addImage()
         }
     }
+
+    private fun onImageClicked() {
+        lifecycleScope.launch {
+            presenter.editImage()
+        }
+    }
+
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -26,6 +26,7 @@ import net.aiscope.gdd_app.ui.snackbar.CustomSnackbarAction
 import java.io.File
 import javax.inject.Inject
 
+@Suppress("TooManyFunctions")
 class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
 
     @Inject

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -18,15 +18,14 @@ import net.aiscope.gdd_app.extensions.select
 import net.aiscope.gdd_app.ui.CaptureFlow
 import net.aiscope.gdd_app.ui.attachCaptureFlowToolbar
 import net.aiscope.gdd_app.ui.capture.CaptureImageActivity
+import net.aiscope.gdd_app.ui.goToHome
 import net.aiscope.gdd_app.ui.goToHomeAndConfirmSaved
-import net.aiscope.gdd_app.ui.main.MainActivity
 import net.aiscope.gdd_app.ui.mask.MaskActivity
 import net.aiscope.gdd_app.ui.snackbar.CustomSnackbar
 import net.aiscope.gdd_app.ui.snackbar.CustomSnackbarAction
 import java.io.File
 import javax.inject.Inject
 
-@Suppress("TooManyFunctions")
 class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
 
     @Inject
@@ -117,12 +116,6 @@ class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
             setTitle(getText(R.string.capture_flow_exit_dialog_title))
             create()
         }.show()
-    }
-
-    fun <T> T.goToHome() where T : AppCompatActivity, T : CaptureFlow {
-        val intent = Intent(this, MainActivity::class.java)
-        intent.flags = Intent.FLAG_ACTIVITY_CLEAR_TOP
-        startActivity(intent)
     }
 
     private fun save() {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -91,12 +91,13 @@ class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
 
     override fun editImage(disease: String, image: File, mask: File){
         val intent = Intent(this, MaskActivity::class.java)
-        //FIXME: where do I get this??
         intent.putExtra(MaskActivity.EXTRA_DISEASE_NAME, disease)
         intent.putExtra(MaskActivity.EXTRA_IMAGE_NAME, image.absolutePath)
 
-        //Doesn't seem to pick up on this
-        intent.putExtra(MaskActivity.EXTRA_MASK_NAME, mask.name)
+        //Remove file extension
+        val maskName = mask.name.removeSuffix(".png")
+        intent.putExtra(MaskActivity.EXTRA_MASK_NAME, maskName)
+        intent.putExtra(MaskActivity.EXTRA_MASK_PATH, mask.path)
 
         startActivity(intent)
     }
@@ -116,9 +117,9 @@ class MetadataActivity : AppCompatActivity(), MetadataView, CaptureFlow {
         }
     }
 
-    private fun onImageClicked() {
+    private fun onImageClicked(index: Int) {
         lifecycleScope.launch {
-            presenter.editImage()
+            presenter.editImage(index)
         }
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataActivity.kt
@@ -4,7 +4,6 @@ import android.content.Intent
 import android.os.Bundle
 import android.view.View
 import android.widget.Toast
-import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.lifecycleScope
 import androidx.recyclerview.widget.LinearLayoutManager
@@ -18,7 +17,6 @@ import net.aiscope.gdd_app.extensions.select
 import net.aiscope.gdd_app.ui.CaptureFlow
 import net.aiscope.gdd_app.ui.attachCaptureFlowToolbar
 import net.aiscope.gdd_app.ui.capture.CaptureImageActivity
-import net.aiscope.gdd_app.ui.goToHome
 import net.aiscope.gdd_app.ui.goToHomeAndConfirmSaved
 import net.aiscope.gdd_app.ui.mask.MaskActivity
 import net.aiscope.gdd_app.ui.showConfirmExitDialog

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
@@ -76,12 +76,12 @@ class MetadataPresenter @Inject constructor(
     }
 
     //Soo I guess we can call this... with WHAT param exactly??
-    suspend fun editImage() {
+    suspend fun editImage(index: Int) {
         val current = repository.current()
         //The sample has images. What I need is an index??
         val image = current.images
         val mask = current.masks
-        //TODO: get the right index
-        view.editImage(current.disease!!, image.elementAt(0), mask.elementAt(0))
+        //TODO: This seems to get the wrong ones. Maybe because we show them in reverse order?
+        view.editImage(current.disease!!, image.elementAt(index), mask.elementAt(index))
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
@@ -74,4 +74,14 @@ class MetadataPresenter @Inject constructor(
         val current = repository.current()
         view.captureImage(current.nextImageName())
     }
+
+    //Soo I guess we can call this... with WHAT param exactly??
+    suspend fun editImage() {
+        val current = repository.current()
+        //The sample has images. What I need is an index??
+        val image = current.images
+        val mask = current.masks
+        //TODO: get the right index
+        view.editImage(current.disease!!, image.elementAt(0), mask.elementAt(0))
+    }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
@@ -75,13 +75,12 @@ class MetadataPresenter @Inject constructor(
         view.captureImage(current.nextImageName())
     }
 
-    //Soo I guess we can call this... with WHAT param exactly??
     suspend fun editImage(index: Int) {
         val current = repository.current()
-        //The sample has images. What I need is an index??
-        val image = current.images
-        val mask = current.masks
-        //TODO: This seems to get the wrong ones. Maybe because we show them in reverse order?
-        view.editImage(current.disease!!, image.elementAt(index), mask.elementAt(index))
+        val images = current.images
+        val masks = current.masks
+
+        //Since the samples are displayed in reverse order, we need to get the image and mask in reverse order too
+        view.editImage(current.disease!!, images.reversed().elementAt(index), masks.reversed().elementAt(index))
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataPresenter.kt
@@ -13,6 +13,7 @@ data class FieldOption(val id: Long, val title: Int)
 data class ViewStateModel(
     val disease: String,
     val images: List<File>,
+    val masks: List<File>,
     val options: List<FieldOption>,
     val required: Boolean = true,
     val smearTypeId: Int? = null,
@@ -40,6 +41,7 @@ class MetadataPresenter @Inject constructor(
             ViewStateModel(
                 sample.disease,
                 sample.images.toList(),
+                sample.masks.toList(),
                 emptyList(),
                 smearTypeId = lastMetadata?.let { metadataMapper.getSmearTypeId(it.smearType) },
                 speciesValue = lastMetadata?.let { metadataMapper.getSpeciesValue(context, it.species) }
@@ -75,12 +77,8 @@ class MetadataPresenter @Inject constructor(
         view.captureImage(current.nextImageName())
     }
 
-    suspend fun editImage(index: Int) {
+    suspend fun editImage(image: File, mask: File) {
         val current = repository.current()
-        val images = current.images
-        val masks = current.masks
-
-        //Since the samples are displayed in reverse order, we need to get the image and mask in reverse order too
-        view.editImage(current.disease!!, images.reversed().elementAt(index), masks.reversed().elementAt(index))
+        view.editImage(current.disease!!, image, mask)
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataView.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/MetadataView.kt
@@ -1,9 +1,12 @@
 package net.aiscope.gdd_app.ui.metadata
 
+import java.io.File
+
 interface MetadataView {
     fun fillForm(model: ViewStateModel)
     fun showInvalidFormError()
     fun captureImage(nextImageName: String)
+    fun editImage(disease: String, image: File, mask: File)
     fun finishFlow()
     fun showRetryBar()
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
@@ -18,7 +18,8 @@ import java.io.File
 
 class SampleImagesAdapter(
     private val uiScope: CoroutineScope,
-    private val onAddImageClicked: () -> Unit
+    private val onAddImageClicked: () -> Unit,
+    private val onImageClicked: () -> Unit
 ) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -28,7 +29,8 @@ class SampleImagesAdapter(
         val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
         return when (viewType) {
             R.layout.item_metadata_add_image -> AddImageViewHolder(view, onAddImageClicked)
-            R.layout.item_metadata_sample_image -> ImageViewHolder(view as ImageView, uiScope)
+            //So this thing gets an action?
+            R.layout.item_metadata_sample_image -> ImageViewHolder(view as ImageView, uiScope, onImageClicked)
             else -> throw IllegalArgumentException("View type $viewType not known")
         }
     }
@@ -36,6 +38,7 @@ class SampleImagesAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
             is AddImageViewHolder -> {}
+            //Sooo this holder should be able to give us the image?
             is ImageViewHolder -> holder.bind(images[position - 1])
             else -> throw IllegalArgumentException("View holder ${holder.javaClass} not known")
         }
@@ -68,7 +71,7 @@ private class AddImageViewHolder(view: View, private val onAddImageClicked: () -
 }
 
 private class ImageViewHolder(
-    view: ImageView, private val uiScope: CoroutineScope
+    view: ImageView, private val uiScope: CoroutineScope, private val onImageClicked: () -> Unit
 ) : RecyclerView.ViewHolder(view) {
     fun bind(image: File) {
         (itemView.tag as? Job)?.cancel()
@@ -80,6 +83,8 @@ private class ImageViewHolder(
                 itemView.context.resources.getDimensionPixelSize(R.dimen.sample_image_thumbnail_height)
             )
             itemView.setImageBitmap(bitmap)
+            //Should we just pass the image here??
+            itemView.setOnClickListener { onImageClicked() }
         }
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
@@ -19,11 +19,12 @@ import java.io.File
 class SampleImagesAdapter(
     private val uiScope: CoroutineScope,
     private val onAddImageClicked: () -> Unit,
-    private val onImageClicked: (Int) -> Unit
+    private val onImageClicked: (File, File) -> Unit
 ) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
     private val images: MutableList<File> = mutableListOf()
+    private val masks: MutableList<File> = mutableListOf()
 
     override fun onCreateViewHolder(parent: ViewGroup, viewType: Int): RecyclerView.ViewHolder {
         val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
@@ -37,7 +38,7 @@ class SampleImagesAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
             is AddImageViewHolder -> {}
-            is ImageViewHolder -> holder.bind(images[position - 1], position - 1)
+            is ImageViewHolder -> holder.bind(images[position - 1], masks[position - 1])
             else -> throw IllegalArgumentException("View holder ${holder.javaClass} not known")
         }
     }
@@ -58,6 +59,13 @@ class SampleImagesAdapter(
         this.images.addAll(images.reversed())
         this.notifyDataSetChanged()
     }
+
+    fun setMasks(masks: List<File>) {
+        this.masks.clear()
+        this.masks.addAll(masks.reversed())
+        this.notifyDataSetChanged()
+    }
+
 }
 
 private class AddImageViewHolder(view: View, private val onAddImageClicked: () -> Unit) :
@@ -69,9 +77,10 @@ private class AddImageViewHolder(view: View, private val onAddImageClicked: () -
 }
 
 private class ImageViewHolder(
-    view: ImageView, private val uiScope: CoroutineScope, private val onImageClicked: (Int) -> Unit
+    view: ImageView, private val uiScope: CoroutineScope, private val onImageClicked: (File, File) -> Unit
 ) : RecyclerView.ViewHolder(view) {
-    fun bind(image: File, index: Int) {
+    //So this bind should happen with a file for the mask too??
+    fun bind(image: File, mask: File) {
         (itemView.tag as? Job)?.cancel()
         itemView.tag = uiScope.launch {
             (itemView as ImageView).setImageBitmap(null)
@@ -81,7 +90,7 @@ private class ImageViewHolder(
                 itemView.context.resources.getDimensionPixelSize(R.dimen.sample_image_thumbnail_height)
             )
             itemView.setImageBitmap(bitmap)
-            itemView.setOnClickListener { onImageClicked(index) }
+            itemView.setOnClickListener { onImageClicked(image, mask) }
         }
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
@@ -29,7 +29,6 @@ class SampleImagesAdapter(
         val view = LayoutInflater.from(parent.context).inflate(viewType, parent, false)
         return when (viewType) {
             R.layout.item_metadata_add_image -> AddImageViewHolder(view, onAddImageClicked)
-            //So this thing gets an action?
             R.layout.item_metadata_sample_image -> ImageViewHolder(view as ImageView, uiScope, onImageClicked)
             else -> throw IllegalArgumentException("View type $viewType not known")
         }
@@ -38,7 +37,6 @@ class SampleImagesAdapter(
     override fun onBindViewHolder(holder: RecyclerView.ViewHolder, position: Int) {
         when (holder) {
             is AddImageViewHolder -> {}
-            //Sooo this holder should be able to give us the image?
             is ImageViewHolder -> holder.bind(images[position - 1], position - 1)
             else -> throw IllegalArgumentException("View holder ${holder.javaClass} not known")
         }
@@ -83,7 +81,6 @@ private class ImageViewHolder(
                 itemView.context.resources.getDimensionPixelSize(R.dimen.sample_image_thumbnail_height)
             )
             itemView.setImageBitmap(bitmap)
-            //Should we just pass the image here??
             itemView.setOnClickListener { onImageClicked(index) }
         }
     }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
@@ -79,7 +79,17 @@ private class AddImageViewHolder(view: View, private val onAddImageClicked: () -
 private class ImageViewHolder(
     view: ImageView, private val uiScope: CoroutineScope, private val onImageClicked: (File, File) -> Unit
 ) : RecyclerView.ViewHolder(view) {
+    private lateinit var imageFile: File
+    private lateinit var maskFile: File
+
+    init {
+        itemView.setOnClickListener { onImageClicked(imageFile, maskFile) }
+    }
+
     fun bind(image: File, mask: File) {
+        imageFile = image
+        maskFile = mask
+
         (itemView.tag as? Job)?.cancel()
         itemView.tag = uiScope.launch {
             (itemView as ImageView).setImageBitmap(null)
@@ -89,7 +99,6 @@ private class ImageViewHolder(
                 itemView.context.resources.getDimensionPixelSize(R.dimen.sample_image_thumbnail_height)
             )
             itemView.setImageBitmap(bitmap)
-            itemView.setOnClickListener { onImageClicked(image, mask) }
         }
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
@@ -19,7 +19,7 @@ import java.io.File
 class SampleImagesAdapter(
     private val uiScope: CoroutineScope,
     private val onAddImageClicked: () -> Unit,
-    private val onImageClicked: () -> Unit
+    private val onImageClicked: (Int) -> Unit
 ) :
     RecyclerView.Adapter<RecyclerView.ViewHolder>() {
 
@@ -39,7 +39,7 @@ class SampleImagesAdapter(
         when (holder) {
             is AddImageViewHolder -> {}
             //Sooo this holder should be able to give us the image?
-            is ImageViewHolder -> holder.bind(images[position - 1])
+            is ImageViewHolder -> holder.bind(images[position - 1], position - 1)
             else -> throw IllegalArgumentException("View holder ${holder.javaClass} not known")
         }
     }
@@ -71,9 +71,9 @@ private class AddImageViewHolder(view: View, private val onAddImageClicked: () -
 }
 
 private class ImageViewHolder(
-    view: ImageView, private val uiScope: CoroutineScope, private val onImageClicked: () -> Unit
+    view: ImageView, private val uiScope: CoroutineScope, private val onImageClicked: (Int) -> Unit
 ) : RecyclerView.ViewHolder(view) {
-    fun bind(image: File) {
+    fun bind(image: File, index: Int) {
         (itemView.tag as? Job)?.cancel()
         itemView.tag = uiScope.launch {
             (itemView as ImageView).setImageBitmap(null)
@@ -84,7 +84,7 @@ private class ImageViewHolder(
             )
             itemView.setImageBitmap(bitmap)
             //Should we just pass the image here??
-            itemView.setOnClickListener { onImageClicked() }
+            itemView.setOnClickListener { onImageClicked(index) }
         }
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/metadata/SampleImagesAdapter.kt
@@ -79,7 +79,6 @@ private class AddImageViewHolder(view: View, private val onAddImageClicked: () -
 private class ImageViewHolder(
     view: ImageView, private val uiScope: CoroutineScope, private val onImageClicked: (File, File) -> Unit
 ) : RecyclerView.ViewHolder(view) {
-    //So this bind should happen with a file for the mask too??
     fun bind(image: File, mask: File) {
         (itemView.tag as? Job)?.cancel()
         itemView.tag = uiScope.launch {


### PR DESCRIPTION
Adds the possibility to click on one of the samples to go back and do some more editing. We also switch from black background JPGs to transparant PNGs for the mask.

It may be a good future improvement to include the mask on the thumbnail to make it more obvious which sample to edit, but out of scope for now.