### PR TITLE
Migrate Crashlytics from Fabric to Firebase

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -3,7 +3,7 @@ apply plugin: 'kotlin-android'
 apply plugin: 'kotlin-android-extensions'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.novoda.build-properties'
-apply plugin: 'io.fabric'
+apply plugin: 'com.google.firebase.crashlytics'
 apply plugin: "io.gitlab.arturbosch.detekt"
 apply plugin: "scabbard.gradle"
 
@@ -48,7 +48,9 @@ android {
     buildTypes {
         debug {
             applicationIdSuffix ".debug"
-            ext.enableCrashlytics = false
+            firebaseCrashlytics {
+                mappingFileUploadEnabled false
+            }
         }
         release {
             signingConfig signingConfigs.release
@@ -98,7 +100,7 @@ dependencies {
 
     // Firebase
     implementation 'com.google.firebase:firebase-analytics:17.4.4'
-    implementation 'com.crashlytics.sdk.android:crashlytics:2.10.1'
+    implementation 'com.google.firebase:firebase-crashlytics:17.2.1'
     implementation 'com.firebaseui:firebase-ui-auth:6.2.1'
     implementation 'com.google.firebase:firebase-common-ktx:19.3.0'
     implementation 'com.google.firebase:firebase-storage-ktx:19.1.1'

--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -20,20 +20,7 @@
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
 
-# https://github.com/aws-amplify/aws-sdk-android/blob/master/Proguard.md
-# Class names are needed in reflection
--keepnames class com.amazonaws.**
--keepnames class com.amazon.**
-# Request handlers defined in request.handlers
-
--keep class com.amazonaws.services.**.*Handler
-
 # Crashlytics
 -keepattributes *Annotation*
 -keepattributes SourceFile,LineNumberTable
 -keep public class * extends java.lang.Exception
--keep class com.crashlytics.** { *; }
--dontwarn com.crashlytics.**
-
-# AWS
--keep class com.amazonaws.mobileconnectors.s3.transferutility.TransferNetworkConnectionType {*;}

--- a/app/src/main/java/net/aiscope/gdd_app/application/GddApplication.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/application/GddApplication.kt
@@ -1,17 +1,17 @@
 package net.aiscope.gdd_app.application
 
 import android.app.Application
+import android.util.Log
 import android.view.TextureView
 import androidx.work.Configuration
 import androidx.work.WorkManager
 import androidx.work.WorkerFactory
-import com.crashlytics.android.Crashlytics
+import com.google.firebase.crashlytics.FirebaseCrashlytics
 import com.smartlook.sdk.smartlook.Smartlook
 import dagger.android.DispatchingAndroidInjector
 import dagger.android.HasAndroidInjector
 import net.aiscope.gdd_app.BuildConfig
 import net.aiscope.gdd_app.dagger.DaggerAppComponent
-import org.jetbrains.annotations.NotNull
 import timber.log.Timber
 import javax.inject.Inject
 
@@ -45,9 +45,18 @@ class GddApplication : Application(), HasAndroidInjector {
 }
 
 /** A tree which logs information for crashlytics reporting. */
-class CrashlyticsReportingTree : @NotNull Timber.Tree() {
+class CrashlyticsReportingTree : Timber.Tree() {
     override fun log(priority: Int, tag: String?, message: String, t: Throwable?) {
-        Crashlytics.log(priority, tag, message)
-        t?.also { Crashlytics.logException(it) }
+        val level = when (priority) {
+            Log.VERBOSE -> "V"
+            Log.DEBUG -> "D"
+            Log.INFO -> "I"
+            Log.WARN -> "W"
+            Log.ERROR -> "E"
+            Log.ASSERT -> "A"
+            else -> "?"
+        }
+        FirebaseCrashlytics.getInstance().log("$level${tag?.let {"/$it"}}: $message")
+        t?.also { FirebaseCrashlytics.getInstance().recordException(it) }
     }
 }

--- a/build.gradle
+++ b/build.gradle
@@ -9,16 +9,13 @@ buildscript {
         google()
         mavenCentral()
         jcenter()
-        maven {
-            url 'https://maven.fabric.io/public'
-        }
     }
     dependencies {
         classpath 'com.android.tools.build:gradle:4.0.1'
         classpath "org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlin_version"
         classpath 'com.novoda:gradle-build-properties-plugin:0.4.1'
         classpath 'com.google.gms:google-services:4.3.3'
-        classpath 'io.fabric.tools:gradle:1.31.2' // Crashlytics plugin
+        classpath 'com.google.firebase:firebase-crashlytics-gradle:2.2.1'
     }
 }
 


### PR DESCRIPTION
https://firebase.google.com/docs/crashlytics/upgrade-sdk?platform=android

Also removes some leftover proguard rules