### PR TITLE
Make sure to only take 1 picture

### DIFF
--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImageActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImageActivity.kt
@@ -94,7 +94,7 @@ class CaptureImageActivity : AppCompatActivity(), CaptureImageView, CaptureFlow 
                     bmp.writeToFileAsync(dest, Bitmap.CompressFormat.JPEG)
                     onPhotoReceived(dest)
                 }
-            } ?: notifyImageCouldNotBeTaken()
+            } ?: lifecycleScope.launch { onPhotoReceived(null) }
         }
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
@@ -6,7 +6,7 @@ import timber.log.Timber
 
 class CaptureImagePresenter(
     val view: CaptureImageView,
-    val repository: SampleRepository,
+    val repository: SampleRepository
 ) {
     var processingImageCapture: Boolean = false
 
@@ -37,5 +37,7 @@ class CaptureImagePresenter(
 
     fun onCaptureError(it: CameraException) {
         Timber.tag("Camera Error").e(it, "capture error")
+        //Allow new photo to be taken on camera error
+        processingImageCapture = false
     }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
@@ -6,20 +6,26 @@ import timber.log.Timber
 
 class CaptureImagePresenter(
     val view: CaptureImageView,
-    val repository: SampleRepository
+    val repository: SampleRepository,
+    var receivedImageCapture: Boolean = false
 ) {
 
     fun handleCaptureImageButton(imageName: String) {
-        Timber.tag("Taking Photo").d("button pressed")
-        view.takePhoto(imageName) { file ->
-            Timber.tag("Taking Photo").d(file?.absolutePath)
-            if (file == null) {
-                view.notifyImageCouldNotBeTaken()
-            } else {
-                val sample = repository.current().addNewlyCapturedImage(file)
-                repository.store(sample)
+        if (receivedImageCapture){
+            Timber.tag("Taking Photo").d("Already processing photo")
+        } else {
+            receivedImageCapture = true
+            Timber.tag("Taking Photo").d("button pressed")
+            view.takePhoto(imageName) { file ->
+                Timber.tag("Taking Photo").d(file?.absolutePath)
+                if (file == null) {
+                    view.notifyImageCouldNotBeTaken()
+                } else {
+                    val sample = repository.current().addNewlyCapturedImage(file)
+                    repository.store(sample)
 
-                view.goToMask(sample.disease, file.absolutePath, sample.nextMaskName())
+                    view.goToMask(sample.disease, file.absolutePath, sample.nextMaskName())
+                }
             }
         }
     }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
@@ -7,15 +7,15 @@ import timber.log.Timber
 class CaptureImagePresenter(
     val view: CaptureImageView,
     val repository: SampleRepository,
-    var receivedImageCapture: Boolean = false
+    var processingImageCapture: Boolean = false
 ) {
 
     fun handleCaptureImageButton(imageName: String) {
-        if (receivedImageCapture){
+        if (processingImageCapture){
             Timber.tag("Taking Photo").d("Already processing photo")
             return
         }
-        receivedImageCapture = true
+        processingImageCapture = true
         Timber.tag("Taking Photo").d("button pressed")
         view.takePhoto(imageName) { file ->
             Timber.tag("Taking Photo").d(file?.absolutePath)
@@ -27,6 +27,8 @@ class CaptureImagePresenter(
 
                 view.goToMask(sample.disease, file.absolutePath, sample.nextMaskName())
             }
+            //What if shit falls over tho??
+            processingImageCapture = false
         }
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
@@ -7,28 +7,31 @@ import timber.log.Timber
 class CaptureImagePresenter(
     val view: CaptureImageView,
     val repository: SampleRepository,
-    var processingImageCapture: Boolean = false
 ) {
+    var processingImageCapture: Boolean = false
 
     fun handleCaptureImageButton(imageName: String) {
+        Timber.tag("Taking Photo").d("button pressed")
         if (processingImageCapture){
             Timber.tag("Taking Photo").d("Already processing photo")
             return
         }
         processingImageCapture = true
-        Timber.tag("Taking Photo").d("button pressed")
         view.takePhoto(imageName) { file ->
-            Timber.tag("Taking Photo").d(file?.absolutePath)
-            if (file == null) {
-                view.notifyImageCouldNotBeTaken()
-            } else {
-                val sample = repository.current().addNewlyCapturedImage(file)
-                repository.store(sample)
+            try{
+                Timber.tag("Taking Photo").d(file?.absolutePath)
+                if (file == null) {
+                    view.notifyImageCouldNotBeTaken()
+                } else {
+                    val sample = repository.current().addNewlyCapturedImage(file)
+                    repository.store(sample)
 
-                view.goToMask(sample.disease, file.absolutePath, sample.nextMaskName())
+                    view.goToMask(sample.disease, file.absolutePath, sample.nextMaskName())
+                }
+            } finally {
+                //Allow new photo to be taken once callback completes
+                processingImageCapture = false
             }
-            //What if shit falls over tho??
-            processingImageCapture = false
         }
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
@@ -8,8 +8,7 @@ class CaptureImagePresenter(
     val view: CaptureImageView,
     val repository: SampleRepository
 ) {
-    //TODO: private field?
-    var processingImageCapture: Boolean = false
+    private var processingImageCapture: Boolean = false
 
     fun handleCaptureImageButton(imageName: String) {
         Timber.tag("Taking Photo").d("button pressed")

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
@@ -8,6 +8,7 @@ class CaptureImagePresenter(
     val view: CaptureImageView,
     val repository: SampleRepository
 ) {
+    //TODO: private field?
     var processingImageCapture: Boolean = false
 
     fun handleCaptureImageButton(imageName: String) {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/capture/CaptureImagePresenter.kt
@@ -13,19 +13,19 @@ class CaptureImagePresenter(
     fun handleCaptureImageButton(imageName: String) {
         if (receivedImageCapture){
             Timber.tag("Taking Photo").d("Already processing photo")
-        } else {
-            receivedImageCapture = true
-            Timber.tag("Taking Photo").d("button pressed")
-            view.takePhoto(imageName) { file ->
-                Timber.tag("Taking Photo").d(file?.absolutePath)
-                if (file == null) {
-                    view.notifyImageCouldNotBeTaken()
-                } else {
-                    val sample = repository.current().addNewlyCapturedImage(file)
-                    repository.store(sample)
+            return
+        }
+        receivedImageCapture = true
+        Timber.tag("Taking Photo").d("button pressed")
+        view.takePhoto(imageName) { file ->
+            Timber.tag("Taking Photo").d(file?.absolutePath)
+            if (file == null) {
+                view.notifyImageCouldNotBeTaken()
+            } else {
+                val sample = repository.current().addNewlyCapturedImage(file)
+                repository.store(sample)
 
-                    view.goToMask(sample.disease, file.absolutePath, sample.nextMaskName())
-                }
+                view.goToMask(sample.disease, file.absolutePath, sample.nextMaskName())
             }
         }
     }

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/CaptureImagePresenterTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/CaptureImagePresenterTest.kt
@@ -33,7 +33,7 @@ class CaptureImagePresenterTest {
     private val presenter = CaptureImagePresenter(view, repository)
 
     @Before
-    fun setUp() = coroutinesTestRule.runBlockingTest {
+    fun setUp(): Unit = runBlocking {
         whenever(repository.current()).thenReturn(sample)
     }
 

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/CaptureImagePresenterTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/CaptureImagePresenterTest.kt
@@ -3,96 +3,78 @@ package net.aiscope.gdd_app.presentation
 import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.mock
+import com.nhaarman.mockito_kotlin.times
 import com.nhaarman.mockito_kotlin.verify
-import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
+import kotlinx.coroutines.runBlocking
 import net.aiscope.gdd_app.CoroutineTestRule
 import net.aiscope.gdd_app.model.Captures
 import net.aiscope.gdd_app.model.Sample
 import net.aiscope.gdd_app.repository.SampleRepository
 import net.aiscope.gdd_app.ui.capture.CaptureImagePresenter
 import net.aiscope.gdd_app.ui.capture.CaptureImageView
-import org.junit.Assert.assertFalse
-import org.junit.Assert.assertTrue
+import org.junit.Before
 import org.junit.Rule
 import org.junit.Test
 import java.io.File
 
 @ExperimentalCoroutinesApi
 class CaptureImagePresenterTest {
+    companion object {
+        private val sample = Sample("an id", "a facility", "a microscopist", "a disease")
+        private val file = File.createTempFile("temp", ".jpg")
+    }
 
     @get:Rule
     var coroutinesTestRule = CoroutineTestRule()
+    private val view: CaptureImageView = mock()
+    private val repository: SampleRepository = mock()
+    private val presenter = CaptureImagePresenter(view, repository)
+
+    @Before
+    fun setUp() = coroutinesTestRule.runBlockingTest {
+        whenever(repository.current()).thenReturn(sample)
+    }
 
     @Test
     fun `capture image should store the image`() = coroutinesTestRule.runBlockingTest {
-        val view: CaptureImageView = mock()
-        val repository: SampleRepository = mock()
-        val sample = Sample("an id", "a facility", "a microscopist", "a disease")
-        val file = File.createTempFile("temp", ".jpg")
-
-        whenever(repository.current()).thenReturn(sample)
-
         whenever(view.takePhoto(any(), any())).doAnswer {
-            val cb = it.getArgument(1) as suspend (File?) -> Unit
-            coroutinesTestRule.runBlockingTest { cb(file) }
-            Unit
+            val onPhotoReceived: suspend (File?) -> Unit = it.getArgument(1)
+            runBlocking { onPhotoReceived(file) }
         }
-
         val presenter = CaptureImagePresenter(view, repository)
         presenter.handleCaptureImageButton("any")
-
         verify(repository).store(sample.copy(captures = Captures().newCapture(file)))
     }
 
-    //FIXME: these basically just test implementation details...
-
     @Test
-    fun `capture image should set and unset processing flag`() = coroutinesTestRule.runBlockingTest {
-        val view: CaptureImageView = mock()
-        val repository: SampleRepository = mock()
-        val sample = Sample("an id", "a facility", "a microscopist", "a disease")
-        val file = File.createTempFile("temp", ".jpg")
-
-        val presenter = CaptureImagePresenter(view, repository)
-
-        whenever(repository.current()).thenReturn(sample)
-
-        whenever(view.takePhoto(any(), any())).doAnswer {
-            val cb = it.getArgument(1) as suspend (File?) -> Unit
-            assertTrue(presenter.processingImageCapture)
-            coroutinesTestRule.runBlockingTest { cb(file) }
-            Unit
-        }
-
+    fun `calling capture image repeatedly takes only one picture`() {
         presenter.handleCaptureImageButton("any")
-
-        verify(repository).store(sample.copy(captures = Captures().newCapture(file)))
-        assertFalse(presenter.processingImageCapture)
+        presenter.handleCaptureImageButton("any")
+        presenter.handleCaptureImageButton("any")
+        verify(view).takePhoto(any(), any())
     }
 
-
     @Test
-    fun `capture image should not store the image if in progress`() = coroutinesTestRule.runBlockingTest {
-        val view: CaptureImageView = mock()
-        val repository: SampleRepository = mock()
-        val sample = Sample("an id", "a facility", "a microscopist", "a disease")
-        val file = File.createTempFile("temp", ".jpg")
-
-        whenever(repository.current()).thenReturn(sample)
-
+    fun `can take picture again after image captured successfully`() {
         whenever(view.takePhoto(any(), any())).doAnswer {
-            val cb = it.getArgument(1) as suspend (File?) -> Unit
-            coroutinesTestRule.runBlockingTest { cb(file) }
-            Unit
+            val onPhotoReceived: suspend (File?) -> Unit = it.getArgument(1)
+            runBlocking { onPhotoReceived(file) }
         }
-
-        val presenter = CaptureImagePresenter(view, repository)
-        presenter.processingImageCapture = true
         presenter.handleCaptureImageButton("any")
-
-        verifyZeroInteractions(repository)
+        presenter.handleCaptureImageButton("any")
+        verify(view, times(2)).takePhoto(any(), any())
     }
 
+    @Test
+    fun `can take picture again after image could't be captured`() {
+        whenever(view.takePhoto(any(), any())).doAnswer {
+            val onPhotoReceived: suspend (File?) -> Unit = it.getArgument(1)
+            runBlocking { onPhotoReceived(null) }
+        }
+        presenter.handleCaptureImageButton("any")
+        presenter.handleCaptureImageButton("any")
+        verify(view, times(2)).takePhoto(any(), any())
+    }
 }

--- a/app/src/test/java/net/aiscope/gdd_app/presentation/CaptureImagePresenterTest.kt
+++ b/app/src/test/java/net/aiscope/gdd_app/presentation/CaptureImagePresenterTest.kt
@@ -4,6 +4,7 @@ import com.nhaarman.mockito_kotlin.any
 import com.nhaarman.mockito_kotlin.doAnswer
 import com.nhaarman.mockito_kotlin.mock
 import com.nhaarman.mockito_kotlin.verify
+import com.nhaarman.mockito_kotlin.verifyZeroInteractions
 import com.nhaarman.mockito_kotlin.whenever
 import kotlinx.coroutines.ExperimentalCoroutinesApi
 import net.aiscope.gdd_app.CoroutineTestRule
@@ -12,6 +13,8 @@ import net.aiscope.gdd_app.model.Sample
 import net.aiscope.gdd_app.repository.SampleRepository
 import net.aiscope.gdd_app.ui.capture.CaptureImagePresenter
 import net.aiscope.gdd_app.ui.capture.CaptureImageView
+import org.junit.Assert.assertFalse
+import org.junit.Assert.assertTrue
 import org.junit.Rule
 import org.junit.Test
 import java.io.File
@@ -41,6 +44,55 @@ class CaptureImagePresenterTest {
         presenter.handleCaptureImageButton("any")
 
         verify(repository).store(sample.copy(captures = Captures().newCapture(file)))
+    }
+
+    //FIXME: these basically just test implementation details...
+
+    @Test
+    fun `capture image should set and unset processing flag`() = coroutinesTestRule.runBlockingTest {
+        val view: CaptureImageView = mock()
+        val repository: SampleRepository = mock()
+        val sample = Sample("an id", "a facility", "a microscopist", "a disease")
+        val file = File.createTempFile("temp", ".jpg")
+
+        val presenter = CaptureImagePresenter(view, repository)
+
+        whenever(repository.current()).thenReturn(sample)
+
+        whenever(view.takePhoto(any(), any())).doAnswer {
+            val cb = it.getArgument(1) as suspend (File?) -> Unit
+            assertTrue(presenter.processingImageCapture)
+            coroutinesTestRule.runBlockingTest { cb(file) }
+            Unit
+        }
+
+        presenter.handleCaptureImageButton("any")
+
+        verify(repository).store(sample.copy(captures = Captures().newCapture(file)))
+        assertFalse(presenter.processingImageCapture)
+    }
+
+
+    @Test
+    fun `capture image should not store the image if in progress`() = coroutinesTestRule.runBlockingTest {
+        val view: CaptureImageView = mock()
+        val repository: SampleRepository = mock()
+        val sample = Sample("an id", "a facility", "a microscopist", "a disease")
+        val file = File.createTempFile("temp", ".jpg")
+
+        whenever(repository.current()).thenReturn(sample)
+
+        whenever(view.takePhoto(any(), any())).doAnswer {
+            val cb = it.getArgument(1) as suspend (File?) -> Unit
+            coroutinesTestRule.runBlockingTest { cb(file) }
+            Unit
+        }
+
+        val presenter = CaptureImagePresenter(view, repository)
+        presenter.processingImageCapture = true
+        presenter.handleCaptureImageButton("any")
+
+        verifyZeroInteractions(repository)
     }
 
 }


### PR DESCRIPTION
Since a microscopist can also take a picture with the 'volume up' button, it is quite possible to accidentally take a bunch. This potentially causes crashes. 

Changed to only process 1 image capture & then go to the masking activity 