### PR TITLE
Migrate to kotlin-parcelize plugin

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -1,6 +1,6 @@
 apply plugin: 'com.android.application'
 apply plugin: 'kotlin-android'
-apply plugin: 'kotlin-android-extensions'
+apply plugin: 'kotlin-parcelize'
 apply plugin: 'kotlin-kapt'
 apply plugin: 'com.novoda.build-properties'
 apply plugin: 'com.google.firebase.crashlytics'
@@ -32,9 +32,6 @@ android {
 
     buildFeatures {
         viewBinding = true
-    }
-    androidExtensions {
-        features = ["parcelize"]
     }
     signingConfigs {
         release {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/BrushDiseaseStage.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/BrushDiseaseStage.kt
@@ -1,7 +1,7 @@
 package net.aiscope.gdd_app.ui.mask
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class BrushDiseaseStage(val id: Int, val name: String, val maskColor: Int) : Parcelable {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomViewBaseState.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/MaskCustomViewBaseState.kt
@@ -1,7 +1,7 @@
 package net.aiscope.gdd_app.ui.mask.customview
 
 import android.os.Parcelable
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 data class MaskCustomViewBaseState(

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/PathAndPaint.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/PathAndPaint.kt
@@ -4,9 +4,9 @@ import android.graphics.Paint
 import android.os.Parcel
 import android.os.Parcelable
 import androidx.core.os.ParcelCompat
-import kotlinx.android.parcel.Parceler
-import kotlinx.android.parcel.Parcelize
-import kotlinx.android.parcel.TypeParceler
+import kotlinx.parcelize.Parceler
+import kotlinx.parcelize.Parcelize
+import kotlinx.parcelize.TypeParceler
 
 @Parcelize
 @TypeParceler<Paint, PaintParceler>

--- a/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/PointToPointPath.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/mask/customview/PointToPointPath.kt
@@ -5,7 +5,7 @@ import android.graphics.PointF
 import android.os.Parcelable
 import androidx.core.graphics.component1
 import androidx.core.graphics.component2
-import kotlinx.android.parcel.Parcelize
+import kotlinx.parcelize.Parcelize
 
 @Parcelize
 @Suppress("DataClassPrivateConstructor")

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,5 +1,5 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-6.7-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-6.7.1-all.zip
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists


### PR DESCRIPTION
Gets rid of the following warning:

```
Warning: The 'kotlin-android-extensions' Gradle plugin is deprecated. Please use this migration guide (https://goo.gle/kotlin-android-extensions-deprecation) to start working with View Binding (https://developer.android.com/topic/libraries/view-binding) and the 'kotlin-parcelize' plugin.
```

Also bumps Gradle wrapper version :)