### PR TITLE
143 tabs

### DIFF
--- a/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/QualityFragment.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/QualityFragment.kt
@@ -30,9 +30,9 @@ class QualityFragment : Fragment(R.layout.fragment_quality) {
             sharedVM.microscopeMagnification,
             sharedVM.microscopeDamaged
         )
-        binding?.apply {
-            binding.microscopeQualityDamagedSwitch.isChecked = sharedVM.microscopeDamaged
-            binding.microscopeQualityMagnificationInput.setText(sharedVM.microscopeMagnification.toString())
+        with(binding) {
+            microscopeQualityDamagedSwitch.isChecked = sharedVM.microscopeDamaged
+            microscopeQualityMagnificationInput.setText(sharedVM.microscopeMagnification.toString())
         }
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/QualityFragment.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/QualityFragment.kt
@@ -10,33 +10,26 @@ import net.aiscope.gdd_app.R
 import net.aiscope.gdd_app.databinding.FragmentQualityBinding
 import timber.log.Timber
 
-class QualityFragment : Fragment() {
+class QualityFragment : Fragment(R.layout.fragment_quality) {
     companion object {
         private const val MAGNIFICATION_MIN = 0
         private const val MAGNIFICATION_MAX = 2000
     }
 
-    private lateinit var binding: FragmentQualityBinding
+    private var _binding: FragmentQualityBinding? = null
+    private val binding get() = _binding!!
 
     //So this should back all 3 fragment 'views'
     private val sharedVM: SampleCompletionViewModel by activityViewModels()
 
-    override fun onCreateView(
-        inflater: LayoutInflater, container: ViewGroup?,
-        savedInstanceState: Bundle?
-    ): View? {
-        binding = FragmentQualityBinding.inflate(inflater, container, false)
+    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
+        super.onViewCreated(view, savedInstanceState)
+        _binding = FragmentQualityBinding.bind(view)
         Timber.i(
             "magnification: %s dam: %s",
             sharedVM.microscopeMagnification,
             sharedVM.microscopeDamaged
         )
-        return binding.root
-    }
-
-    override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
-        super.onViewCreated(view, savedInstanceState)
-
         binding?.apply {
             binding.microscopeQualityDamagedSwitch.isChecked = sharedVM.microscopeDamaged
             binding.microscopeQualityMagnificationInput.setText(sharedVM.microscopeMagnification.toString())
@@ -68,4 +61,8 @@ class QualityFragment : Fragment() {
         }
     }
 
+    override fun onDestroy() {
+        super.onDestroy()
+        _binding = null
+    }
 }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/SampleCompletionActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/SampleCompletionActivity.kt
@@ -1,15 +1,12 @@
 package net.aiscope.gdd_app.ui.sample_completion
 
 import android.os.Bundle
-import android.view.View
 import androidx.activity.viewModels
 import androidx.appcompat.app.AppCompatActivity
 import androidx.lifecycle.ViewModelProvider
-import androidx.lifecycle.lifecycleScope
 import com.google.android.material.snackbar.Snackbar
 import com.google.android.material.tabs.TabLayout
 import dagger.android.AndroidInjection
-import kotlinx.coroutines.launch
 import net.aiscope.gdd_app.R
 import net.aiscope.gdd_app.databinding.ActivityCompleteSampleBinding
 import net.aiscope.gdd_app.ui.CaptureFlow
@@ -31,9 +28,6 @@ class SampleCompletionActivity : CaptureFlow, AppCompatActivity() {
         AndroidInjection.inject(this)
         super.onCreate(savedInstanceState)
 
-        //FIXME Bit sloppy
-        val context = this
-
         binding = ActivityCompleteSampleBinding.inflate(layoutInflater)
         with(binding) {
             setContentView(root)
@@ -44,7 +38,7 @@ class SampleCompletionActivity : CaptureFlow, AppCompatActivity() {
             tabLayout.addTab(tabLayout.newTab().setText(R.string.complete_sample_quality_tab))
             tabLayout.tabGravity = TabLayout.GRAVITY_FILL
             val adapter = FragmentAdapter(
-                context, supportFragmentManager,
+                this@SampleCompletionActivity, supportFragmentManager,
                 tabLayout.tabCount
             )
             viewPager.adapter = adapter
@@ -66,15 +60,12 @@ class SampleCompletionActivity : CaptureFlow, AppCompatActivity() {
         }
 
         //Initialize the shared viewmodel for the tabs
-        lifecycleScope.launch {
             sharedVM.initVM()
-        }
     }
 
     fun save() {
         //So how do I get the fragments??
 //        supportFragmentManager.findFragmentById()
-        lifecycleScope.launch {
             try{
                 sharedVM.save()
                 finishFlow()
@@ -82,7 +73,6 @@ class SampleCompletionActivity : CaptureFlow, AppCompatActivity() {
                 Timber.e(error, "An error occurred when saving sample preparation")
                 showRetryBar()
             }
-        }
     }
 
     fun showRetryBar() {
@@ -91,12 +81,10 @@ class SampleCompletionActivity : CaptureFlow, AppCompatActivity() {
             getString(R.string.microscope_quality_snackbar_error),
             Snackbar.LENGTH_INDEFINITE, null,
             CustomSnackbarAction(
-                getString(R.string.microscope_quality_snackbar_retry),
-                View.OnClickListener {
-                    lifecycleScope.launch {
-                        sharedVM.save()
-                    }
-                })
+                getString(R.string.microscope_quality_snackbar_retry)
+            ) {
+                sharedVM.save()
+            }
         ).show()
     }
 


### PR DESCRIPTION
The viewbinding can leak in fragments, so you have to assign a null when the fragment is destroyed.

A recommended way to use the coroutines inside the viewmodel is using viewmodel scope, the advantage it gives us is that it's lifecycle aware so the viewmodel will be the responsible for the suspended function it calls.

I wrote a TODO, because its a good practice to inject the coroutines dispatcher so you can change it for the test one while testing, but I will comment it in a meeting to see if we want to do that.