### PR TITLE
Demo branch from  old build. Store sample data , whenever SampleCompletionActivity is closed

### DIFF
--- a/app/src/main/java/net/aiscope/gdd_app/model/SampleModels.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/model/SampleModels.kt
@@ -53,12 +53,14 @@ enum class WaterType(val id: Int) {
     DISTILLED(1),
     BOTTLED(2),
     TAP(3),
-    WELL(4)
+    WELL(4),
+    UNDECLARED(5)
 }
 
 enum class SampleAge(val id: String) {
     FRESH("fresh"),
-    OLD("old")
+    OLD("old"),
+    UNDECLARED("")
 }
 
 data class MicroscopeQuality(

--- a/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/repository/SampleRepositorySharedPreference.kt
@@ -65,7 +65,8 @@ class SampleRepositorySharedPreference @Inject constructor(
     override suspend fun lastSaved(): Sample? {
         val allStores = all()
         return allStores
-            .filter { s -> s.status != SampleStatus.Incomplete }
+            //.filter { s -> s.status != SampleStatus.Incomplete }
+            // TODO: Not sure of Status field usage
             .maxByOrNull { it.createdOn }
     }
 

--- a/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/SampleCompletionActivity.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/SampleCompletionActivity.kt
@@ -124,9 +124,9 @@ class SampleCompletionActivity : CaptureFlow, AppCompatActivity() {
         }
     }
 
-    fun saveToVM() {
+    fun saveToVM(doEnqueueRemote: Boolean) {
         try {
-            sharedVM.save()
+            sharedVM.save(doEnqueueRemote)
             finishFlow()
         } catch (@Suppress("TooGenericExceptionCaught") error: Throwable) {
             Timber.e(error, "An error occurred when saving sample completion data")
@@ -142,7 +142,7 @@ class SampleCompletionActivity : CaptureFlow, AppCompatActivity() {
             CustomSnackbarAction(
                 getString(R.string.microscope_quality_snackbar_retry)
             ) {
-                sharedVM.save()
+                sharedVM.save(true)
             }
         ).show()
     }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/behaviours/FormTrainingFirstTime.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/behaviours/FormTrainingFirstTime.kt
@@ -13,7 +13,7 @@ class FormTrainingFirstTime  : FormTraining {
         {
             if(sa.isCurrentTabLastStep())
             {
-                sa.saveToVM()
+                sa.saveToVM(true)
             }
             else
             {

--- a/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/behaviours/FormTrainingIsComplete.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/behaviours/FormTrainingIsComplete.kt
@@ -7,7 +7,7 @@ class FormTrainingIsComplete : FormTraining {
     override fun getSubmitOnClickListener(sa: SampleCompletionActivity) {
         val erroneousTab = sa.validateTabsAndUpdateVM()
         if (erroneousTab == null) {
-            sa.saveToVM()
+            sa.saveToVM(true)
         } else {
             sa.setActiveTab(erroneousTab)
         }

--- a/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/metadata/MetadataFragment.kt
+++ b/app/src/main/java/net/aiscope/gdd_app/ui/sample_completion/metadata/MetadataFragment.kt
@@ -46,21 +46,29 @@ class MetadataFragment : SampleFormFragment, Fragment(R.layout.fragment_metadata
 
                 smearTypeId?.let { metadataSectionSmearTypeRadioGroup.check(it) }
                 speciesValue?.let { metadataSpeciesSpinner.select(it) }
+                comments?.let {
+                    metadataCommentsInput.setText(it)
+                }
             }
         }
     }
 
-    override fun validateAndUpdateVM(): Boolean {
+    fun updateVM() {
         with(binding) {
             sharedVM.smearTypeId = metadataSectionSmearTypeRadioGroup.checkedRadioButtonId
             sharedVM.speciesValue = metadataSpeciesSpinner.selectedItem.toString()
             sharedVM.comments = metadataCommentsInput.text.toString()
         }
+    }
+    override fun validateAndUpdateVM(): Boolean {
+        updateVM()
         //No validation on this tab
         return true
     }
 
     private fun onAddImageClicked() {
+        updateVM()
+        sharedVM.save(false)
         lifecycleScope.launch {
             val intent = Intent(context, CaptureImageActivity::class.java)
             intent.putExtra(
@@ -72,6 +80,8 @@ class MetadataFragment : SampleFormFragment, Fragment(R.layout.fragment_metadata
     }
 
     private fun onImageClicked(capture: CompletedCapture) {
+        updateVM()
+        sharedVM.save(false)
         lifecycleScope.launch {
             val intent = Intent(context, MaskActivity::class.java)
             intent.putExtra(MaskActivity.EXTRA_DISEASE_NAME, sharedVM.disease)


### PR DESCRIPTION
_This is not a PR for merge_

Changes are previewed in this PR. Some TODOs added in codebase to share concerns.

whenever SampleCompletionActivity is closed  :-
1. Store data in SharedPreferences, without sending to remote
2. Allow storing data without validation, when not sending to remote
3. Add new enum as default values for various properties, when storing without validation

Pros : 
1. Maintains current architecture without introducing new data storage 
2. Avoids passing around of intent during user navigation

Cons :
1. Data validation responsibility belongs to UI. Can be added to model layer too, but will need work