### PR TITLE
Do not obfuscate field names

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -25,6 +25,9 @@
 -keepattributes SourceFile,LineNumberTable
 -keep public class * extends java.lang.Exception
 
+# Do not obfuscate field names, ends up with a/b/c/d properties in firestore
+-keep public class net.aiscope.gdd_app.**{*;}
+
 # Build issues with R8
 -dontwarn com.amplitude.api.*
 -dontwarn com.bugsnag.android.*


### PR DESCRIPTION
R8 obfuscated field names which is why we ended up with entities in firestore that are all named 'a' 'b' 'c' etc